### PR TITLE
Use swiftly to build

### DIFF
--- a/Sources/EdgeCLI/SwiftPM.swift
+++ b/Sources/EdgeCLI/SwiftPM.swift
@@ -1,12 +1,41 @@
 import Foundation
-import Shell
+import Subprocess
 
 /// Represents the Swift Package Manager interface for building and managing Swift packages.
 public struct SwiftPM: Sendable {
     public let path: String
 
-    public init(path: String = "/usr/bin/swift") {
+    /// Default Swift version to use for building packages
+    public static let defaultSwiftVersion = "+6.1"
+
+    /// Custom Swift version, defaults to defaultSwiftVersion if nil
+    public let swiftVersion: String?
+
+    public init(path: String = "swiftly run swift", swiftVersion: String? = nil) {
         self.path = path
+        self.swiftVersion = swiftVersion
+    }
+
+    /// Find the absolute path for an executable using the 'which' command
+    private func findExecutablePath(for command: String) async throws -> String {
+        // If command already includes spaces, it's likely a command with args
+        // In this case, we'll just extract the first part to look up
+        let commandName = command.split(separator: " ").first.map(String.init) ?? command
+
+        let result = try await Subprocess.run(
+            Subprocess.Executable.path("/usr/bin/which"),
+            arguments: Subprocess.Arguments([commandName]),
+            output: .string,
+            error: .discarded
+        )
+
+        if let path = result.standardOutput?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !path.isEmpty
+        {
+            return path
+        }
+
+        return commandName  // Fallback to original command name
     }
 
     public enum BuildOption: Sendable {
@@ -54,14 +83,78 @@ public struct SwiftPM: Sendable {
 
     /// Build the Swift package.
     @discardableResult public func build(_ options: BuildOption...) async throws -> String {
-        let arguments = [path, "build"] + options.flatMap(\.arguments)
-        return try await Shell.run(arguments)
+        let version = swiftVersion ?? Self.defaultSwiftVersion
+
+        // Find the executable path
+        let executablePath = try await findExecutablePath(
+            for: path.split(separator: " ").first.map(String.init) ?? path
+        )
+        // print("Using swiftly at path: \(executablePath)")
+
+        // Use the executable path instead of just the command name
+        let runArgs = path.split(separator: " ").dropFirst().map(String.init)
+        let allArgs =
+            [executablePath] + runArgs + ["build", version] + options.flatMap(\.arguments)
+
+        let result = try await Subprocess.run(
+            Subprocess.Executable.path("/usr/bin/env"),
+            arguments: Subprocess.Arguments(allArgs),
+            output: .string,
+            error: .string
+        )
+
+        if result.terminationStatus.isSuccess {
+            return result.standardOutput ?? ""
+        } else {
+            throw SubprocessError.nonZeroExit(
+                command: allArgs.joined(separator: " "),
+                exitCode: Int(result.terminationStatus.description) ?? -1,
+                output: result.standardOutput ?? "",
+                error: result.standardError ?? ""
+            )
+        }
     }
 
     public func dumpPackage() async throws -> Package {
-        let arguments = [path, "package", "dump-package"]
-        let output = try await Shell.run(arguments)
-        return try JSONDecoder().decode(Package.self, from: Data(output.utf8))
+        // Find the executable path
+        let executablePath = try await findExecutablePath(
+            for: path.split(separator: " ").first.map(String.init) ?? path
+        )
+        print("Using swiftly at path: \(executablePath)")
+
+        // Use the executable path instead of just the command name
+        let runArgs = path.split(separator: " ").dropFirst().map(String.init)
+        let allArgs = [executablePath] + runArgs + ["package", "dump-package"]
+
+        let result = try await Subprocess.run(
+            Subprocess.Executable.path("/usr/bin/env"),
+            arguments: Subprocess.Arguments(allArgs),
+            output: .string,
+            error: .string
+        )
+
+        if result.terminationStatus.isSuccess, let output = result.standardOutput {
+            return try JSONDecoder().decode(Package.self, from: Data(output.utf8))
+        } else {
+            throw SubprocessError.nonZeroExit(
+                command: allArgs.joined(separator: " "),
+                exitCode: Int(result.terminationStatus.description) ?? -1,
+                output: result.standardOutput ?? "",
+                error: result.standardError ?? ""
+            )
+        }
+    }
+
+    /// Error thrown when a subprocess execution fails.
+    public enum SubprocessError: Error, LocalizedError {
+        case nonZeroExit(command: String, exitCode: Int, output: String, error: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .nonZeroExit(let command, let exitCode, _, let error):
+                return "Command '\(command)' failed with exit code \(exitCode): \(error)"
+            }
+        }
     }
 
     /// The return type of the `dumpPackage` method.

--- a/Sources/edge/cli/commands/OSCommand.swift
+++ b/Sources/edge/cli/commands/OSCommand.swift
@@ -1,0 +1,325 @@
+import ArgumentParser
+import Foundation
+import Imager
+
+#if os(macOS)
+    import Darwin
+#elseif os(Linux)
+    // No explicit libc import needed when using musl
+#endif
+
+// Helper function to safely flush output without referring to stdout directly
+// This avoids concurrency issues with global variables
+@inline(__always) private func flushOutput() {
+    // Simply print an empty string with a newline to force flush
+    // This is a simple workaround that doesn't require accessing global C variables
+    print("", terminator: "")
+}
+
+struct OSCommand: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "os",
+        abstract: "Manage EdgeOS installations.",
+        subcommands: [
+            ListCommand.self, ListDevicesCommand.self, WriteCommand.self, WriteDeviceCommand.self,
+        ]
+    )
+
+    struct ListCommand: AsyncParsableCommand {
+
+        static let configuration = CommandConfiguration(
+            commandName: "show-drives",
+            abstract: "List available external drives."
+        )
+
+        @Flag(name: .long, help: "List all drives, not just external drives")
+        var all: Bool = false
+
+        func run() async throws {
+            let diskLister = DiskListerFactory.createDiskLister()
+            let drives = try await diskLister.list(all: all)
+
+            if drives.isEmpty {
+                print("No external drives found.")
+            } else {
+                print("\nAvailable external drives:")
+                print("---------------------------")
+
+                for (index, drive) in drives.enumerated() {
+                    print("[\(index + 1)] \(drive.name) (\(drive.id))")
+                    print("    Capacity: \(drive.capacityHumanReadableText)")
+                    print("    Available: \(drive.availableHumanReadableText)")
+                    print("    Type: \(drive.isExternal ? "External" : "Internal")")
+                    print("")
+                }
+            }
+        }
+    }
+
+    struct ListDevicesCommand: AsyncParsableCommand {
+
+        static let configuration = CommandConfiguration(
+            commandName: "devices",
+            abstract: "List supported devices."
+        )
+
+        func run() async throws {
+            print("📱 Fetching supported devices...")
+
+            let manifestManager = ManifestManagerFactory.createManifestManager()
+            let deviceList = try await manifestManager.getAvailableDevices()
+
+            if deviceList.isEmpty {
+                print("No devices found in the manifest.")
+            } else {
+                print("\nAvailable devices:")
+                print("------------------")
+
+                for (index, deviceInfo) in deviceList.enumerated() {
+                    print("[\(index + 1)] \(deviceInfo.name)")
+                    if !deviceInfo.latestVersion.isEmpty {
+                        print("    Latest version: \(deviceInfo.latestVersion)")
+                    } else {
+                        print("    No version available")
+                    }
+                    print("")
+                }
+
+                print("To write a device image: edge imager write-device <device-name> <drive-id>")
+                print("Example: edge imager write-device raspberry-pi-5 disk2")
+            }
+        }
+    }
+
+    struct WriteCommand: AsyncParsableCommand {
+
+        static let configuration = CommandConfiguration(
+            commandName: "write",
+            abstract: "Write an image to a drive."
+        )
+
+        @Argument(help: "Path to the image file to write")
+        var imagePath: String
+
+        @Argument(help: "Target drive to write to")
+        var driveId: String
+
+        func run() async throws {
+            // Use DiskLister to find the drive
+            let diskLister = DiskListerFactory.createDiskLister()
+            let drive = try await diskLister.findDrive(byId: driveId)
+
+            // Use DiskWriter to write the image
+            let diskWriter = DiskWriterFactory.createDiskWriter()
+
+            // Create a progress bar
+            print("Starting to write image to \(drive.name) (\(drive.id))")
+            print("Press Ctrl+C to cancel")
+
+            // Track the last update time to avoid too frequent updates
+            var lastUpdateTime = Date()
+
+            try await diskWriter.write(imagePath: imagePath, drive: drive) { progress in
+                // Update progress at most once per second to avoid flooding the terminal
+                let now = Date()
+                if now.timeIntervalSince(lastUpdateTime) >= 1.0 {
+                    lastUpdateTime = now
+
+                    // Clear the current line
+                    print("\r\u{1B}[K", terminator: "")
+
+                    // Print progress information
+                    if let percent = progress.percentComplete {
+                        // Use the new ASCII progress bar
+                        let progressBar = progress.asciiProgress(
+                            totalBlocks: 30,
+                            appendPercentageText: false
+                        )
+
+                        // Print progress with percentage and written/total bytes
+                        if let totalText = progress.totalBytesText {
+                            print(
+                                "\r\(progressBar) \(String(format: "%.1f%%", percent)) - \(progress.bytesWrittenText)/\(totalText)",
+                                terminator: ""
+                            )
+                        } else {
+                            print(
+                                "\r\(progressBar) \(String(format: "%.1f%%", percent)) - \(progress.bytesWrittenText)",
+                                terminator: ""
+                            )
+                        }
+                    } else {
+                        // If we don't know the percentage, just show bytes written
+                        print("\rWritten: \(progress.bytesWrittenText)", terminator: "")
+                    }
+
+                    // Force output to be displayed without accessing stdout directly
+                    flushOutput()
+                }
+            }
+
+            // Clear the line and print completion message
+            print("\r\u{1B}[K", terminator: "")
+            print("✅ Image successfully written to \(drive.name)")
+        }
+    }
+
+    struct WriteDeviceCommand: AsyncParsableCommand {
+
+        static let configuration = CommandConfiguration(
+            commandName: "write-device",
+            abstract: "Download and write the latest image for a specific device."
+        )
+
+        @Argument(help: "Device name (e.g., raspberry-pi-5)")
+        var deviceName: String
+
+        @Argument(help: "Target drive to write to")
+        var driveId: String
+
+        @Flag(name: .long, help: "Skip confirmation before writing")
+        var force: Bool = false
+
+        func run() async throws {
+            // Use DiskLister to find the drive
+            let diskLister = DiskListerFactory.createDiskLister()
+            let drive = try await diskLister.findDrive(byId: driveId)
+
+            print("🔍 Finding latest image for \(deviceName)...")
+
+            // Get the latest image information for the device
+            let manifestManager = ManifestManagerFactory.createManifestManager()
+            let (imageUrl, imageSize) = try await manifestManager.getLatestImageInfo(
+                for: deviceName
+            )
+
+            print("📥 Found image: \(imageUrl.lastPathComponent)")
+            print(
+                "   Size: \(ByteCountFormatter.string(fromByteCount: Int64(imageSize), countStyle: .file))"
+            )
+
+            // Confirm with the user before proceeding
+            if !force {
+                print("\n⚠️  WARNING: All data on \(drive.name) (\(drive.id)) will be erased.")
+                print("   Type 'yes' to continue or any other key to abort:")
+
+                let response = readLine()?.lowercased()
+                guard response == "yes" else {
+                    print("Operation aborted.")
+                    return
+                }
+            }
+
+            // Download the image
+            print("\n📥 Downloading image...")
+            let imageDownloader = ImageDownloaderFactory.createImageDownloader()
+            var lastUpdateTime = Date()
+
+            let localImagePath = try await imageDownloader.downloadImage(
+                from: imageUrl,
+                expectedSize: imageSize
+            ) { progress in
+                // Update progress at most once per second
+                let now = Date()
+                if now.timeIntervalSince(lastUpdateTime) >= 1.0 {
+                    lastUpdateTime = now
+
+                    // Clear the current line
+                    print("\r\u{1B}[K", terminator: "")
+
+                    if let percent = progress.percentComplete {
+                        // Use ASCII progress bar
+                        let progressBar = progress.asciiProgress(
+                            totalBlocks: 30,
+                            appendPercentageText: false
+                        )
+
+                        // Print progress with percentage and downloaded/total bytes
+                        if let totalText = progress.totalBytesText {
+                            print(
+                                "\r\(progressBar) \(String(format: "%.1f%%", percent)) - \(progress.bytesWrittenText)/\(totalText)",
+                                terminator: ""
+                            )
+                        } else {
+                            print(
+                                "\r\(progressBar) \(String(format: "%.1f%%", percent)) - \(progress.bytesWrittenText)",
+                                terminator: ""
+                            )
+                        }
+                    } else {
+                        // If we don't know the percentage, just show bytes downloaded
+                        print("\rDownloaded: \(progress.bytesWrittenText)", terminator: "")
+                    }
+
+                    // Force output to be displayed without accessing stdout directly
+                    flushOutput()
+                }
+            }
+
+            // Clear the line and print completion message
+            print("\r\u{1B}[K", terminator: "")
+            print("✅ Image downloaded to: \(localImagePath)")
+            print("\n💾 Writing image to \(drive.name) (\(drive.id))...")
+            print("   Press Ctrl+C to cancel")
+
+            // Use DiskWriter to write the image
+            let diskWriter = DiskWriterFactory.createDiskWriter()
+            lastUpdateTime = Date()
+
+            try await diskWriter.write(imagePath: localImagePath, drive: drive) { progress in
+                // Update progress at most once per second
+                let now = Date()
+                if now.timeIntervalSince(lastUpdateTime) >= 1.0 {
+                    lastUpdateTime = now
+
+                    // Clear the current line
+                    print("\r\u{1B}[K", terminator: "")
+
+                    if let percent = progress.percentComplete {
+                        // Use ASCII progress bar
+                        let progressBar = progress.asciiProgress(
+                            totalBlocks: 30,
+                            appendPercentageText: false
+                        )
+
+                        // Print progress with percentage and written/total bytes
+                        if let totalText = progress.totalBytesText {
+                            print(
+                                "\r\(progressBar) \(String(format: "%.1f%%", percent)) - \(progress.bytesWrittenText)/\(totalText)",
+                                terminator: ""
+                            )
+                        } else {
+                            print(
+                                "\r\(progressBar) \(String(format: "%.1f%%", percent)) - \(progress.bytesWrittenText)",
+                                terminator: ""
+                            )
+                        }
+                    } else {
+                        // If we don't know the percentage, just show bytes written
+                        print("\rWritten: \(progress.bytesWrittenText)", terminator: "")
+                    }
+
+                    // Force output to be displayed without accessing stdout directly
+                    flushOutput()
+                }
+            }
+
+            // Clear the line and print completion message
+            print("\r\u{1B}[K", terminator: "")
+            print("✅ Image successfully written to \(drive.name)")
+
+            // Delete the temporary image file
+            do {
+                try FileManager.default.removeItem(atPath: localImagePath)
+                print("🗑️  Temporary image file removed")
+            } catch {
+                print(
+                    "⚠️  Warning: Could not remove temporary image file: \(error.localizedDescription)"
+                )
+            }
+
+            print("\n🎉 Device \(deviceName) successfully imaged!")
+        }
+    }
+}


### PR DESCRIPTION
An issue we have with the client is it defaults to `/usr/bin/swift` to build, which might be the apple specific toolchain. 

We need to use the proper toolchain to build the apps to run on edge devices.

A few things happening here:
- switch from using Shell to Subprocess since it has been successful in other areas of the codebase
- find swiftly using `which`
- use `swiftly run build <version> ....` to build edge apps.
