### PR TITLE
edge init also generates .edge and creates the project dir if needed

### DIFF
--- a/Sources/edge/cli/commands/InitCommand.swift
+++ b/Sources/edge/cli/commands/InitCommand.swift
@@ -1,5 +1,12 @@
 import ArgumentParser
-import Shell
+import Subprocess
+import System
+
+#if canImport(FoundationEssentials)
+    import FoundationEssentials
+#else
+    import Foundation
+#endif
 
 struct InitCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -7,10 +14,72 @@ struct InitCommand: AsyncParsableCommand {
         abstract: "Initialize a new EdgeOS project in the current directory."
     )
 
+    @Option(
+        name: .customLong("path"),
+        help: "Path where the project should be created (defaults to current directory)"
+    )
+    var projectPath: String = "."
+
     func run() async throws {
-        print("Initializing new EdgeOS project...")
-        try await Shell.run([
-            "swift", "package", "init", "--type", "executable",
-        ])
+        print("Initializing new EdgeOS project at \(projectPath)...")
+
+        // Create the directory if it doesn't exist
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: projectPath) {
+            do {
+                try fileManager.createDirectory(
+                    atPath: projectPath,
+                    withIntermediateDirectories: true
+                )
+                print("Created directory: \(projectPath)")
+            } catch {
+                throw InitError.directoryCreationFailed(
+                    path: projectPath,
+                    error: error.localizedDescription
+                )
+            }
+        }
+
+        // Run swift package init in the specified directory
+        let result = try await Subprocess.run(
+            Subprocess.Executable.name("swift"),
+            arguments: ["package", "init", "--type", "executable"],
+            workingDirectory: FilePath(projectPath),
+            output: .string,
+            error: .string
+        )
+
+        if !result.terminationStatus.isSuccess {
+            throw InitError.commandFailed(
+                command: "swift package init --type executable",
+                exitCode: Int(result.terminationStatus.description) ?? -1,
+                error: result.standardError ?? ""
+            )
+        }
+
+        // Create .edge directory inside the project path
+        let edgeDirPath =
+            projectPath.hasSuffix("/") ? "\(projectPath).edge" : "\(projectPath)/.edge"
+
+        do {
+            try fileManager.createDirectory(atPath: edgeDirPath, withIntermediateDirectories: true)
+            print("Created .edge directory in \(projectPath)")
+        } catch {
+            print("Warning: Failed to create .edge directory: \(error.localizedDescription)")
+        }
+    }
+}
+
+enum InitError: Error {
+    case commandFailed(command: String, exitCode: Int, error: String)
+    case directoryCreationFailed(path: String, error: String)
+
+    var localizedDescription: String {
+        switch self {
+        case .commandFailed(let command, let exitCode, let error):
+            return "Command '\(command)' failed with exit code \(exitCode): \(error)"
+        case .directoryCreationFailed(let path, let error):
+            return "Failed to create directory at '\(path)': \(error)"
+        }
     }
 }

--- a/Sources/edge/cli/commands/InitCommand.swift
+++ b/Sources/edge/cli/commands/InitCommand.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
 import Subprocess
-import System
+import SystemPackage
 
 #if canImport(FoundationEssentials)
     import FoundationEssentials
@@ -40,18 +40,18 @@ struct InitCommand: AsyncParsableCommand {
             }
         }
 
-        // Run swift package init in the specified directory
+        // Run swift package init in the specified directory using bash -c to cd into the directory first
+        let command = "cd \"\(projectPath)\" && swift package init --type executable"
         let result = try await Subprocess.run(
-            Subprocess.Executable.name("swift"),
-            arguments: ["package", "init", "--type", "executable"],
-            workingDirectory: FilePath(projectPath),
+            Subprocess.Executable.name("bash"),
+            arguments: Subprocess.Arguments(["-c", command]),
             output: .string,
             error: .string
         )
 
         if !result.terminationStatus.isSuccess {
             throw InitError.commandFailed(
-                command: "swift package init --type executable",
+                command: command,
                 exitCode: Int(result.terminationStatus.description) ?? -1,
                 error: result.standardError ?? ""
             )


### PR DESCRIPTION
- `edge init --path <project path>` will create the project directory if it doesn't exist and initialize in that directory. --path defaults to `.`
- `edge init` creates a `.edge` empty directory. this is a little hack that gets VSCode to recognize it as an Edge project rather than just a swift package