### PR TITLE
Add flags to remove dead code and symbols for edge-agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,13 @@ jobs:
             args+=(--swift-sdk "${{ matrix.swift-sdk }}")
           fi
 
+          # Add optimization flags for edge-agent builds
+          if [ "${{ matrix.product }}" == "edge-agent" ]; then
+            args+=(-Xswiftc -whole-module-optimization)
+            args+=(-Xlinker --gc-sections)
+            args+=(-Xlinker --strip-all)
+          fi
+
           swift build "${args[@]}"
 
           # Copy built binary to the output directory

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,16 @@ build-agent: _protos ## Build the edge agent executable
 	@echo "Binary size: $$(du -h edge-agent | cut -f1)"
 
 build-agent-release: _protos ## Build the edge agent executable in release mode
-	swiftly run swift build +6.1 --swift-sdk aarch64-swift-linux-musl --product edge-agent -c release
+	swiftly run swift build +6.1 --swift-sdk aarch64-swift-linux-musl \
+	--product edge-agent \
+	-c release \
+	-Xswiftc -whole-module-optimization \
+	-Xlinker --gc-sections \
+	-Xlinker --strip-all
+
 	cp .build/aarch64-swift-linux-musl/release/edge-agent .
+	strip edge-agent 2>/dev/null || true
+
 	chmod +x edge-agent
 	@echo "Binary size: $$(du -h edge-agent | cut -f1)"
 


### PR DESCRIPTION
The linker flags do the following:

  -Xlinker --gc-sections: Removes unused code sections from the final binary. The linker
  identifies functions and data that are never referenced and excludes them, reducing
  binary size.

  -Xlinker --strip-all: Removes all symbol table and debugging information from the binary.
   This eliminates function names, variable names, and debug symbols, significantly
  reducing file size but making debugging impossible.

  Both flags help minimize the edge-agent binary size, which is useful for deployment in
  resource-constrained environments.
