### PR TITLE
EDG-175 create lanchd daemon with xpc no business logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ DerivedData/
 .vscode
 coverage_report/
 Examples/HelloHTTP/HelloHTTP-container.tar
+
+# Generated app bundle
+EdgeCLI.app/

--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
                 .target(name: "Imager"),
                 .target(name: "ContainerRegistry"),
                 .target(name: "DownloadSupport"),
+                .target(name: "CliXPCProtocol"),
             ],
             resources: [
                 .copy("Resources")

--- a/Sources/edge-network-daemon/edge-network-daemon.entitlements
+++ b/Sources/edge-network-daemon/edge-network-daemon.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/Sources/edge/Resources/Info.plist
+++ b/Sources/edge/Resources/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>edge</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.edgeos.edge-cli</string>
+	<key>CFBundleName</key>
+	<string>EdgeOS CLI</string>
+	<key>CFBundleDisplayName</key>
+	<string>EdgeOS CLI</string>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>15.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>SMPrivilegedExecutables</key>
+	<dict>
+		<key>com.edgeos.edge-network-daemon</key>
+		<string>identifier "com.edgeos.edge-network-daemon"</string>
+	</dict>
+</dict>
+</plist> 

--- a/Sources/edge/Resources/com.edgeos.edge-network-daemon.plist
+++ b/Sources/edge/Resources/com.edgeos.edge-network-daemon.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.edgeos.edge-network-daemon</string>
+	<key>BundleProgram</key>
+	<string>Contents/MacOS/edge-network-daemon</string>
+	<key>MachServices</key>
+	<dict>
+		<key>com.edgeos.edge-network-daemon</key>
+		<true/>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist> 

--- a/Sources/edge/Resources/com.edgeos.helper.plist
+++ b/Sources/edge/Resources/com.edgeos.helper.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.edgeos.helper</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__EDGE_HELPER_PATH__</string>
+		<string>--foreground</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>__HOME_DIR__/Library/Logs/edge-helper.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME_DIR__/Library/Logs/edge-helper.log</string>
+	<key>WorkingDirectory</key>
+	<string>__HOME_DIR__</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist> 

--- a/Sources/edge/utils/SMAppServiceManager.swift
+++ b/Sources/edge/utils/SMAppServiceManager.swift
@@ -1,0 +1,216 @@
+import CliXPCProtocol
+import Foundation
+import Logging
+
+#if os(macOS)
+    import ServiceManagement
+
+    /// Modern SMAppService-based daemon management
+    public actor SMAppServiceManager {
+        private let logger: Logger
+        private let daemonIdentifier = "com.edgeos.edge-network-daemon"
+
+        public init(logger: Logger) {
+            self.logger = logger
+        }
+
+        /// Register and start the privileged daemon using SMAppService
+        public func installDaemon() async throws {
+            logger.info("Installing edge-network-daemon using SMAppService")
+
+            // Create the daemon service
+            let service = SMAppService.daemon(plistName: "\(daemonIdentifier).plist")
+
+            do {
+                // Register the daemon - this will prompt for Touch ID/password
+                try service.register()
+                logger.info("Successfully registered edge-network-daemon")
+
+                // Wait a moment for the service to start
+                try await Task.sleep(for: .seconds(2))
+
+                // Verify it's running
+                let status = service.status
+                logger.info("Daemon status after registration: \(status.rawValue)")
+
+                switch status {
+                case .enabled:
+                    logger.info("✅ Daemon is enabled and should be running")
+                case .requiresApproval:
+                    logger.warning("⚠️ Daemon requires user approval in System Settings")
+                    throw SMAppServiceError.requiresApproval
+                case .notRegistered:
+                    throw SMAppServiceError.registrationFailed
+                case .notFound:
+                    throw SMAppServiceError.daemonNotFound
+                @unknown default:
+                    logger.warning("Unknown daemon status: \(status.rawValue)")
+                }
+
+            } catch {
+                logger.error("Failed to register daemon: \(error)")
+                throw error
+            }
+        }
+
+        /// Unregister the daemon
+        public func uninstallDaemon() async throws {
+            logger.info("Uninstalling edge-network-daemon")
+
+            let service = SMAppService.daemon(plistName: "\(daemonIdentifier).plist")
+
+            do {
+                try await service.unregister()
+                logger.info("Successfully unregistered edge-network-daemon")
+            } catch {
+                logger.error("Failed to unregister daemon: \(error)")
+                throw error
+            }
+        }
+
+        /// Get current daemon status
+        public func getDaemonStatus() -> SMAppService.Status {
+            let service = SMAppService.daemon(plistName: "\(daemonIdentifier).plist")
+            return service.status
+        }
+
+        /// Test XPC connection to the daemon
+        public func testConnection() async throws {
+            logger.info("Testing XPC connection to daemon")
+
+            let connection = NSXPCConnection(
+                machServiceName: kEdgeNetworkDaemonServiceName,
+                options: .privileged
+            )
+            connection.remoteObjectInterface = NSXPCInterface(with: EdgeNetworkDaemonProtocol.self)
+            connection.resume()
+
+            defer { connection.invalidate() }
+
+            let remoteProxy = connection.remoteObjectProxy as? EdgeNetworkDaemonProtocol
+
+            return try await withCheckedThrowingContinuation { continuation in
+                remoteProxy?.handshake { success, error in
+                    if success {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: error ?? XPCError.connectionFailed)
+                    }
+                }
+            }
+        }
+
+        /// Get detailed daemon status information
+        public func getDaemonStatusInfo() async -> DaemonStatusInfo {
+            let status = getDaemonStatus()
+
+            var xpcConnected = false
+            var xpcError: Error?
+
+            // Test XPC connection if daemon is enabled
+            if status == .enabled {
+                do {
+                    try await testConnection()
+                    xpcConnected = true
+                } catch {
+                    xpcError = error
+                }
+            }
+
+            return DaemonStatusInfo(
+                status: status,
+                isXPCConnected: xpcConnected,
+                xpcError: xpcError
+            )
+        }
+    }
+
+    /// Detailed daemon status information
+    public struct DaemonStatusInfo: Sendable {
+        public let status: SMAppService.Status
+        public let isXPCConnected: Bool
+        public let xpcError: Error?
+
+        public var statusDescription: String {
+            switch status {
+            case .enabled:
+                return isXPCConnected ? "Running" : "Enabled but not responding"
+            case .requiresApproval:
+                return "Requires Approval"
+            case .notRegistered:
+                return "Not Installed"
+            case .notFound:
+                return "Daemon Not Found"
+            @unknown default:
+                return "Unknown (\(status.rawValue))"
+            }
+        }
+    }
+
+    /// Errors for SMAppService operations
+    public enum SMAppServiceError: Error, LocalizedError {
+        case registrationFailed
+        case requiresApproval
+        case daemonNotFound
+        case connectionFailed
+
+        public var errorDescription: String? {
+            switch self {
+            case .registrationFailed:
+                return "Failed to register daemon with SMAppService"
+            case .requiresApproval:
+                return "Daemon requires approval in System Settings > General > Login Items"
+            case .daemonNotFound:
+                return "Daemon executable not found"
+            case .connectionFailed:
+                return "Failed to connect to daemon via XPC"
+            }
+        }
+    }
+
+#else
+    // Fallback for non-macOS platforms
+    public actor SMAppServiceManager {
+        private let logger: Logger
+
+        public init(logger: Logger) {
+            self.logger = logger
+        }
+
+        public func installDaemon() async throws {
+            logger.error("SMAppService is only available on macOS")
+            throw SMAppServiceError.registrationFailed
+        }
+
+        public func uninstallDaemon() async throws {
+            logger.error("SMAppService is only available on macOS")
+            throw SMAppServiceError.registrationFailed
+        }
+
+        public func testConnection() async throws {
+            logger.error("XPC is only available on macOS")
+            throw SMAppServiceError.connectionFailed
+        }
+
+        public func getDaemonStatusInfo() async -> DaemonStatusInfo {
+            return DaemonStatusInfo(
+                status: .notFound,
+                isXPCConnected: false,
+                xpcError: SMAppServiceError.registrationFailed
+            )
+        }
+    }
+
+    // Provide minimal types for non-macOS
+    public struct DaemonStatusInfo {
+        public let status: MockStatus
+        public let isXPCConnected: Bool
+        public let xpcError: Error?
+
+        public var statusDescription: String { "Unsupported Platform" }
+    }
+
+    public enum MockStatus: Int {
+        case notFound = 0
+    }
+#endif


### PR DESCRIPTION
EDG-175 EDG-176

Add edge-network-daemon with SMAppService integration

  - Create edge-network-daemon binary target with XPC service
  - Add SMAppService registration to edge helper install command
  - Set up proper app bundle structure for codesigned daemons
  - Move network daemon binary to Contents/MacOS/ per SMAppService requirements
  - Add build-app-bundle Makefile target with codesigning support
  - Move entitlements file to Sources/edge-network-daemon/
  - Update .gitignore to exclude generated EdgeCLI.app bundle
