### PR TITLE
Add edge-network-daemon with SMAppService integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ DerivedData/
 .vscode
 coverage_report/
 Examples/HelloHTTP/HelloHTTP-container.tar
+
+# Generated app bundle
+EdgeCLI.app/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
   PLATFORM := unknown
 endif
 
-.PHONY: all clean edge edge-agent help format setup-hooks build proto deps
+.PHONY: all clean edge edge-agent help format setup-hooks build proto deps build-network-daemon build-app-bundle
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -20,7 +20,7 @@ help: ## Show this help message
 	@echo 'Targets:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
 
-all: build-cli build-helper build-agent ## Build all executables
+all: build-cli build-helper build-network-daemon build-agent ## Build all executables
 
 install-deps: ## Install dependencies needed for building
 	brew install protoc-gen-grpc-swift
@@ -37,6 +37,35 @@ build-helper: _protos ## Build the edge helper daemon executable
 	swift build --product edge-helper
 	echo "y" | cp -f .build/$(PLATFORM)/debug/edge-helper ~/bin/edge-helper
 	chmod +x ~/bin/edge-helper
+
+build-network-daemon: _protos ## Build the edge network daemon executable
+	swift build --product edge-network-daemon
+	echo "y" | cp -f .build/$(PLATFORM)/debug/edge-network-daemon ~/bin/edge-network-daemon
+	chmod +x ~/bin/edge-network-daemon
+
+build-app-bundle: build-cli build-helper build-network-daemon ## Build and codesign the EdgeCLI.app bundle
+	@echo "Building EdgeCLI.app bundle..."
+	mkdir -p EdgeCLI.app/Contents/MacOS
+	mkdir -p EdgeCLI.app/Contents/Resources
+	mkdir -p EdgeCLI.app/Contents/Library/LaunchDaemons
+	
+	# Copy binaries
+	cp .build/$(PLATFORM)/debug/edge EdgeCLI.app/Contents/MacOS/
+	cp .build/$(PLATFORM)/debug/edge-helper EdgeCLI.app/Contents/Resources/
+	cp .build/$(PLATFORM)/debug/edge-network-daemon EdgeCLI.app/Contents/MacOS/
+	
+	# Copy resources
+	cp Sources/edge/Resources/Info.plist EdgeCLI.app/Contents/
+	cp Sources/edge/Resources/com.edgeos.helper.plist EdgeCLI.app/Contents/Resources/
+	cp Sources/edge/Resources/com.edgeos.edge-network-daemon.plist EdgeCLI.app/Contents/Library/LaunchDaemons/
+	
+	# Codesign the bundle
+	codesign --force --options runtime --entitlements Sources/edge-network-daemon/edge-network-daemon.entitlements --sign "$(CODESIGN_IDENTITY)" EdgeCLI.app/Contents/MacOS/edge-network-daemon
+	codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" EdgeCLI.app/Contents/Resources/edge-helper
+	codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" EdgeCLI.app/Contents/MacOS/edge
+	codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" EdgeCLI.app
+	
+	@echo "✅ EdgeCLI.app bundle built and codesigned"
 
 build-cli-linux: _protos ## build the edge CLI for linux with musl
 	swiftly run swift build +6.1 --swift-sdk aarch64-swift-linux-musl --product edge -c release

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .executable(name: "edge-agent", targets: ["edge-agent"]),
         .executable(name: "edge", targets: ["edge"]),
         .executable(name: "edge-helper", targets: ["edge-helper"]),
+        .executable(name: "edge-network-daemon", targets: ["edge-network-daemon"]),
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
@@ -45,6 +46,7 @@ let package = Package(
                 .target(name: "Imager"),
                 .target(name: "ContainerRegistry"),
                 .target(name: "DownloadSupport"),
+                .target(name: "CliXPCProtocol"),
             ],
             resources: [
                 .copy("Resources")
@@ -174,6 +176,23 @@ let package = Package(
                 .target(name: "EdgeShared"),
                 // Reuse existing device discovery components
                 .target(name: "edge"), // For device discovery protocols
+            ]
+        ),
+
+        /// XPC Protocol for communication between CLI and privileged daemon
+        .target(
+            name: "CliXPCProtocol",
+            dependencies: []
+        ),
+
+        /// The privileged network daemon for macOS
+        .executableTarget(
+            name: "edge-network-daemon",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Logging", package: "swift-log"),
+                .target(name: "EdgeShared"),
+                .target(name: "CliXPCProtocol"),
             ]
         ),
 

--- a/Sources/CliXPCProtocol/XPCProtocol.swift
+++ b/Sources/CliXPCProtocol/XPCProtocol.swift
@@ -4,7 +4,7 @@ import Foundation
 @objc public protocol EdgeNetworkDaemonProtocol {
     /// Basic handshake to verify daemon is responding
     func handshake(completion: @escaping (Bool, Error?) -> Void)
-    
+
     /// Execute privileged network configuration with authorization
     func configureNetwork(
         authorizationData: Data,
@@ -12,7 +12,7 @@ import Foundation
         ipAddress: String,
         completion: @escaping (Bool, Error?) -> Void
     )
-    
+
     /// Get daemon version
     func getVersion(completion: @escaping (String?, Error?) -> Void)
 }
@@ -23,7 +23,7 @@ public enum XPCError: Error, LocalizedError {
     case authorizationInvalid
     case networkConfigurationFailed(String)
     case daemonNotRunning
-    
+
     public var errorDescription: String? {
         switch self {
         case .connectionFailed:
@@ -42,4 +42,4 @@ public enum XPCError: Error, LocalizedError {
 public let kEdgeNetworkDaemonServiceName = "com.edgeos.edge-network-daemon"
 
 /// Custom authorization right for network configuration
-public let kEdgeNetworkConfigurationRight = "com.edgeos.configure.network" 
+public let kEdgeNetworkConfigurationRight = "com.edgeos.configure.network"

--- a/Sources/CliXPCProtocol/XPCProtocol.swift
+++ b/Sources/CliXPCProtocol/XPCProtocol.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// XPC Protocol for communication between edge CLI and edge-network-daemon
+@objc public protocol EdgeNetworkDaemonProtocol {
+    /// Basic handshake to verify daemon is responding
+    func handshake(completion: @escaping (Bool, Error?) -> Void)
+    
+    /// Execute privileged network configuration with authorization
+    func configureNetwork(
+        authorizationData: Data,
+        interfaceName: String,
+        ipAddress: String,
+        completion: @escaping (Bool, Error?) -> Void
+    )
+    
+    /// Get daemon version
+    func getVersion(completion: @escaping (String?, Error?) -> Void)
+}
+
+/// Error types for XPC communication
+public enum XPCError: Error, LocalizedError {
+    case connectionFailed
+    case authorizationInvalid
+    case networkConfigurationFailed(String)
+    case daemonNotRunning
+    
+    public var errorDescription: String? {
+        switch self {
+        case .connectionFailed:
+            return "Failed to connect to network daemon"
+        case .authorizationInvalid:
+            return "Invalid authorization provided"
+        case .networkConfigurationFailed(let message):
+            return "Network configuration failed: \(message)"
+        case .daemonNotRunning:
+            return "Network daemon is not running"
+        }
+    }
+}
+
+/// XPC Service identifier
+public let kEdgeNetworkDaemonServiceName = "com.edgeos.edge-network-daemon"
+
+/// Custom authorization right for network configuration
+public let kEdgeNetworkConfigurationRight = "com.edgeos.configure.network" 

--- a/Sources/edge-network-daemon/edge-network-daemon.entitlements
+++ b/Sources/edge-network-daemon/edge-network-daemon.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/Sources/edge-network-daemon/main.swift
+++ b/Sources/edge-network-daemon/main.swift
@@ -1,0 +1,113 @@
+import ArgumentParser
+import Foundation
+import Logging
+import CliXPCProtocol
+
+@main
+struct EdgeNetworkDaemon: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "edge-network-daemon",
+        abstract: "EdgeOS privileged network configuration daemon",
+        version: "1.0.0"
+    )
+    
+    @Flag(name: .shortAndLong, help: "Enable debug logging")
+    var debug = false
+    
+    func run() async throws {
+        // Set up logging
+        let logLevel: Logger.Level = debug ? .debug : .info
+        LoggingSystem.bootstrap { label in
+            var handler = StreamLogHandler.standardError(label: label)
+            handler.logLevel = logLevel
+            return handler
+        }
+        
+        let logger = Logger(label: "edge-network-daemon")
+        
+        logger.info("Starting Edge Network Daemon")
+        
+        // Create and start the XPC listener
+        let service = EdgeNetworkDaemonService(logger: logger)
+        let listener = NSXPCListener(machServiceName: kEdgeNetworkDaemonServiceName)
+        listener.delegate = service
+        listener.resume()
+        
+        logger.info("Edge Network Daemon listening on: \(kEdgeNetworkDaemonServiceName)")
+        
+        // Keep daemon running - wait indefinitely
+        do {
+            while true {
+                try await Task.sleep(for: .seconds(60))
+            }
+        } catch {
+            logger.info("Daemon stopped: \(error)")
+        }
+    }
+}
+
+/// XPC Service implementation
+class EdgeNetworkDaemonService: NSObject, NSXPCListenerDelegate {
+    private let logger: Logger
+    
+    init(logger: Logger) {
+        self.logger = logger
+        super.init()
+    }
+    
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        logger.debug("Received new XPC connection from PID: \(newConnection.processIdentifier)")
+        
+        // Set up the connection
+        newConnection.exportedInterface = NSXPCInterface(with: EdgeNetworkDaemonProtocol.self)
+        
+        let exportedObject = EdgeNetworkDaemonImplementation(logger: logger)
+        newConnection.exportedObject = exportedObject
+        
+        newConnection.invalidationHandler = { [weak self] in
+            self?.logger.debug("XPC connection invalidated")
+        }
+        
+        newConnection.interruptionHandler = { [weak self] in
+            self?.logger.debug("XPC connection interrupted")
+        }
+        
+        newConnection.resume()
+        return true
+    }
+}
+
+/// Implementation of the XPC protocol
+class EdgeNetworkDaemonImplementation: NSObject, EdgeNetworkDaemonProtocol {
+    private let logger: Logger
+    
+    init(logger: Logger) {
+        self.logger = logger
+        super.init()
+    }
+    
+    func handshake(completion: @escaping (Bool, Error?) -> Void) {
+        logger.debug("Received handshake request")
+        completion(true, nil)
+    }
+    
+    func configureNetwork(
+        authorizationData: Data,
+        interfaceName: String,
+        ipAddress: String,
+        completion: @escaping (Bool, Error?) -> Void
+    ) {
+        logger.info("Received network configuration request for interface: \(interfaceName)")
+        
+        // For now, just log the request - we'll implement the actual logic later
+        logger.info("Would configure interface \(interfaceName) with IP \(ipAddress)")
+        logger.info("Authorization data size: \(authorizationData.count) bytes")
+        
+        // Return success for now
+        completion(true, nil)
+    }
+    
+    func getVersion(completion: @escaping (String?, Error?) -> Void) {
+        completion("1.0.0", nil)
+    }
+} 

--- a/Sources/edge/Resources/Info.plist
+++ b/Sources/edge/Resources/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>edge</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.edgeos.edge-cli</string>
+	<key>CFBundleName</key>
+	<string>EdgeOS CLI</string>
+	<key>CFBundleDisplayName</key>
+	<string>EdgeOS CLI</string>
+	<key>CFBundleVersion</key>
+	<string>1.0.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>15.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>SMPrivilegedExecutables</key>
+	<dict>
+		<key>com.edgeos.edge-network-daemon</key>
+		<string>identifier "com.edgeos.edge-network-daemon"</string>
+	</dict>
+</dict>
+</plist> 

--- a/Sources/edge/Resources/com.edgeos.edge-network-daemon.plist
+++ b/Sources/edge/Resources/com.edgeos.edge-network-daemon.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.edgeos.edge-network-daemon</string>
+	<key>BundleProgram</key>
+	<string>Contents/MacOS/edge-network-daemon</string>
+	<key>MachServices</key>
+	<dict>
+		<key>com.edgeos.edge-network-daemon</key>
+		<true/>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist> 

--- a/Sources/edge/Resources/com.edgeos.helper.plist
+++ b/Sources/edge/Resources/com.edgeos.helper.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.edgeos.helper</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__EDGE_HELPER_PATH__</string>
+		<string>--foreground</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>__HOME_DIR__/Library/Logs/edge-helper.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME_DIR__/Library/Logs/edge-helper.log</string>
+	<key>WorkingDirectory</key>
+	<string>__HOME_DIR__</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist> 

--- a/Sources/edge/utils/SMAppServiceManager.swift
+++ b/Sources/edge/utils/SMAppServiceManager.swift
@@ -1,0 +1,216 @@
+import CliXPCProtocol
+import Foundation
+import Logging
+
+#if os(macOS)
+    import ServiceManagement
+
+    /// Modern SMAppService-based daemon management
+    public actor SMAppServiceManager {
+        private let logger: Logger
+        private let daemonIdentifier = "com.edgeos.edge-network-daemon"
+
+        public init(logger: Logger) {
+            self.logger = logger
+        }
+
+        /// Register and start the privileged daemon using SMAppService
+        public func installDaemon() async throws {
+            logger.info("Installing edge-network-daemon using SMAppService")
+
+            // Create the daemon service
+            let service = SMAppService.daemon(plistName: "\(daemonIdentifier).plist")
+
+            do {
+                // Register the daemon - this will prompt for Touch ID/password
+                try service.register()
+                logger.info("Successfully registered edge-network-daemon")
+
+                // Wait a moment for the service to start
+                try await Task.sleep(for: .seconds(2))
+
+                // Verify it's running
+                let status = service.status
+                logger.info("Daemon status after registration: \(status.rawValue)")
+
+                switch status {
+                case .enabled:
+                    logger.info("✅ Daemon is enabled and should be running")
+                case .requiresApproval:
+                    logger.warning("⚠️ Daemon requires user approval in System Settings")
+                    throw SMAppServiceError.requiresApproval
+                case .notRegistered:
+                    throw SMAppServiceError.registrationFailed
+                case .notFound:
+                    throw SMAppServiceError.daemonNotFound
+                @unknown default:
+                    logger.warning("Unknown daemon status: \(status.rawValue)")
+                }
+
+            } catch {
+                logger.error("Failed to register daemon: \(error)")
+                throw error
+            }
+        }
+
+        /// Unregister the daemon
+        public func uninstallDaemon() async throws {
+            logger.info("Uninstalling edge-network-daemon")
+
+            let service = SMAppService.daemon(plistName: "\(daemonIdentifier).plist")
+
+            do {
+                try await service.unregister()
+                logger.info("Successfully unregistered edge-network-daemon")
+            } catch {
+                logger.error("Failed to unregister daemon: \(error)")
+                throw error
+            }
+        }
+
+        /// Get current daemon status
+        public func getDaemonStatus() -> SMAppService.Status {
+            let service = SMAppService.daemon(plistName: "\(daemonIdentifier).plist")
+            return service.status
+        }
+
+        /// Test XPC connection to the daemon
+        public func testConnection() async throws {
+            logger.info("Testing XPC connection to daemon")
+
+            let connection = NSXPCConnection(
+                machServiceName: kEdgeNetworkDaemonServiceName,
+                options: .privileged
+            )
+            connection.remoteObjectInterface = NSXPCInterface(with: EdgeNetworkDaemonProtocol.self)
+            connection.resume()
+
+            defer { connection.invalidate() }
+
+            let remoteProxy = connection.remoteObjectProxy as? EdgeNetworkDaemonProtocol
+
+            return try await withCheckedThrowingContinuation { continuation in
+                remoteProxy?.handshake { success, error in
+                    if success {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: error ?? XPCError.connectionFailed)
+                    }
+                }
+            }
+        }
+
+        /// Get detailed daemon status information
+        public func getDaemonStatusInfo() async -> DaemonStatusInfo {
+            let status = getDaemonStatus()
+
+            var xpcConnected = false
+            var xpcError: Error?
+
+            // Test XPC connection if daemon is enabled
+            if status == .enabled {
+                do {
+                    try await testConnection()
+                    xpcConnected = true
+                } catch {
+                    xpcError = error
+                }
+            }
+
+            return DaemonStatusInfo(
+                status: status,
+                isXPCConnected: xpcConnected,
+                xpcError: xpcError
+            )
+        }
+    }
+
+    /// Detailed daemon status information
+    public struct DaemonStatusInfo: Sendable {
+        public let status: SMAppService.Status
+        public let isXPCConnected: Bool
+        public let xpcError: Error?
+
+        public var statusDescription: String {
+            switch status {
+            case .enabled:
+                return isXPCConnected ? "Running" : "Enabled but not responding"
+            case .requiresApproval:
+                return "Requires Approval"
+            case .notRegistered:
+                return "Not Installed"
+            case .notFound:
+                return "Daemon Not Found"
+            @unknown default:
+                return "Unknown (\(status.rawValue))"
+            }
+        }
+    }
+
+    /// Errors for SMAppService operations
+    public enum SMAppServiceError: Error, LocalizedError {
+        case registrationFailed
+        case requiresApproval
+        case daemonNotFound
+        case connectionFailed
+
+        public var errorDescription: String? {
+            switch self {
+            case .registrationFailed:
+                return "Failed to register daemon with SMAppService"
+            case .requiresApproval:
+                return "Daemon requires approval in System Settings > General > Login Items"
+            case .daemonNotFound:
+                return "Daemon executable not found"
+            case .connectionFailed:
+                return "Failed to connect to daemon via XPC"
+            }
+        }
+    }
+
+#else
+    // Fallback for non-macOS platforms
+    public actor SMAppServiceManager {
+        private let logger: Logger
+
+        public init(logger: Logger) {
+            self.logger = logger
+        }
+
+        public func installDaemon() async throws {
+            logger.error("SMAppService is only available on macOS")
+            throw SMAppServiceError.registrationFailed
+        }
+
+        public func uninstallDaemon() async throws {
+            logger.error("SMAppService is only available on macOS")
+            throw SMAppServiceError.registrationFailed
+        }
+
+        public func testConnection() async throws {
+            logger.error("XPC is only available on macOS")
+            throw SMAppServiceError.connectionFailed
+        }
+
+        public func getDaemonStatusInfo() async -> DaemonStatusInfo {
+            return DaemonStatusInfo(
+                status: .notFound,
+                isXPCConnected: false,
+                xpcError: SMAppServiceError.registrationFailed
+            )
+        }
+    }
+
+    // Provide minimal types for non-macOS
+    public struct DaemonStatusInfo {
+        public let status: MockStatus
+        public let isXPCConnected: Bool
+        public let xpcError: Error?
+
+        public var statusDescription: String { "Unsupported Platform" }
+    }
+
+    public enum MockStatus: Int {
+        case notFound = 0
+    }
+#endif


### PR DESCRIPTION
  - Create edge-network-daemon binary target with XPC service
  - Add SMAppService registration to edge helper install command
  - Set up proper app bundle structure for codesigned daemons
  - Move network daemon binary to Contents/MacOS/ per SMAppService requirements
  - Add build-app-bundle Makefile target with codesigning support
  - Move entitlements file to Sources/edge-network-daemon/
  - Update .gitignore to exclude generated EdgeCLI.app bundle