### PR TITLE
Use system events to detect new edgeOS devices connected to macOS

### DIFF
--- a/Sources/edge-helper/Services/IOKitService.swift
+++ b/Sources/edge-helper/Services/IOKitService.swift
@@ -1,0 +1,107 @@
+#if os(macOS)
+
+    import Foundation
+    import IOKit
+    import IOKit.usb
+    import IOKit.usb.IOUSBLib
+
+    /// Protocol for abstracting IOKit operations to enable testing
+    protocol IOKitServiceProtocol {
+        /// Creates an IOKit notification port
+        func createNotificationPort() -> IONotificationPortRef?
+
+        /// Gets the run loop source for a notification port
+        func getRunLoopSource(_ port: IONotificationPortRef) -> CFRunLoopSource?
+
+        /// Creates a matching dictionary for USB devices
+        func createUSBDeviceMatchingDictionary() -> CFMutableDictionary?
+
+        /// Adds a matching notification for device events
+        func addMatchingNotification(
+            port: IONotificationPortRef,
+            type: String,
+            matching: CFMutableDictionary,
+            callback: IOServiceMatchingCallback,
+            refcon: UnsafeMutableRawPointer,
+            iterator: UnsafeMutablePointer<io_iterator_t>
+        ) -> kern_return_t
+
+        /// Gets the next device from an iterator
+        func iteratorNext(_ iterator: io_iterator_t) -> io_service_t
+
+        /// Releases an IOKit object
+        func objectRelease(_ object: io_object_t)
+
+        /// Gets device properties from an io_service_t
+        func getDeviceProperties(_ device: io_service_t) -> [String: Any]?
+
+        /// Destroys a notification port
+        func destroyNotificationPort(_ port: IONotificationPortRef)
+    }
+
+    /// Real implementation that wraps actual IOKit APIs
+    struct RealIOKitService: IOKitServiceProtocol {
+
+        func createNotificationPort() -> IONotificationPortRef? {
+            return IONotificationPortCreate(kIOMainPortDefault)
+        }
+
+        func getRunLoopSource(_ port: IONotificationPortRef) -> CFRunLoopSource? {
+            guard let unmanagedSource = IONotificationPortGetRunLoopSource(port) else {
+                return nil
+            }
+            return unmanagedSource.takeUnretainedValue()
+        }
+
+        func createUSBDeviceMatchingDictionary() -> CFMutableDictionary? {
+            return IOServiceMatching(kIOUSBDeviceClassName)
+        }
+
+        func addMatchingNotification(
+            port: IONotificationPortRef,
+            type: String,
+            matching: CFMutableDictionary,
+            callback: IOServiceMatchingCallback,
+            refcon: UnsafeMutableRawPointer,
+            iterator: UnsafeMutablePointer<io_iterator_t>
+        ) -> kern_return_t {
+            return IOServiceAddMatchingNotification(
+                port,
+                type,
+                matching,
+                callback,
+                refcon,
+                iterator
+            )
+        }
+
+        func iteratorNext(_ iterator: io_iterator_t) -> io_service_t {
+            return IOIteratorNext(iterator)
+        }
+
+        func objectRelease(_ object: io_object_t) {
+            IOObjectRelease(object)
+        }
+
+        func getDeviceProperties(_ device: io_service_t) -> [String: Any]? {
+            var properties: Unmanaged<CFMutableDictionary>?
+            let result = IORegistryEntryCreateCFProperties(
+                device,
+                &properties,
+                kCFAllocatorDefault,
+                0
+            )
+
+            guard result == KERN_SUCCESS, let props = properties?.takeRetainedValue() else {
+                return nil
+            }
+
+            return props as NSDictionary as? [String: Any]
+        }
+
+        func destroyNotificationPort(_ port: IONotificationPortRef) {
+            IONotificationPortDestroy(port)
+        }
+    }
+
+#endif  // os(macOS)

--- a/Sources/edge-helper/Services/IOKitUSBMonitor.swift
+++ b/Sources/edge-helper/Services/IOKitUSBMonitor.swift
@@ -1,0 +1,309 @@
+#if os(macOS)
+
+    import EdgeShared
+    import Foundation
+    import Logging
+    import IOKit
+    import IOKit.usb
+    import IOKit.usb.IOUSBLib
+
+    /// Event-driven USB monitor using IOKit notifications
+    /// This replaces polling with real-time USB device connection/disconnection events
+    actor IOKitUSBMonitor: USBMonitorService {
+        private let logger: Logger
+        private var deviceHandler: (@Sendable (USBDeviceEvent) -> Void)?
+        private var isRunning = false
+
+        // IOKit notification handling
+        private var notificationPort: IONotificationPortRef?
+        private var runLoopSource: CFRunLoopSource?
+        private var matchedIterator: io_iterator_t = 0
+        private var terminatedIterator: io_iterator_t = 0
+        private var runLoop: CFRunLoop?
+        private var monitoringTask: Task<Void, Never>?
+
+        init(logger: Logger) {
+            self.logger = logger
+        }
+
+        func start() async throws {
+            guard !isRunning else {
+                logger.debug("IOKit USB monitor already running")
+                return
+            }
+
+            logger.info("Starting IOKit USB device monitoring...")
+
+            // Create notification port
+            notificationPort = IONotificationPortCreate(kIOMainPortDefault)
+            guard let notificationPort = notificationPort else {
+                throw USBMonitorError.failedToCreateNotificationPort
+            }
+
+            // Get the run loop source
+            if let unmanagedSource = IONotificationPortGetRunLoopSource(notificationPort) {
+                runLoopSource = unmanagedSource.takeUnretainedValue()
+            } else {
+                throw USBMonitorError.failedToCreateNotificationPort
+            }
+
+            // Create matching dictionary for USB devices
+            guard let matchingDict = IOServiceMatching(kIOUSBDeviceClassName) else {
+                throw USBMonitorError.failedToCreateMatchingDictionary
+            }
+
+            // Add the notification port to a background run loop
+            monitoringTask = Task {
+                await withTaskCancellationHandler {
+                    await runNotificationLoop()
+                } onCancel: {
+                    // Cleanup will be handled in stop()
+                }
+            }
+
+            // Register for device matched notifications (device connected)
+            let matchedCallback: IOServiceMatchingCallback = { (refcon, iterator) in
+                let monitor = Unmanaged<IOKitUSBMonitor>.fromOpaque(refcon!).takeUnretainedValue()
+                Task {
+                    await monitor.handleDeviceMatched(iterator: iterator)
+                }
+            }
+
+            let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+            let result = IOServiceAddMatchingNotification(
+                notificationPort,
+                kIOMatchedNotification,
+                matchingDict,
+                matchedCallback,
+                selfPtr,
+                &matchedIterator
+            )
+
+            guard result == KERN_SUCCESS else {
+                throw USBMonitorError.failedToRegisterNotification("matched", result)
+            }
+
+            // Register for device terminated notifications (device disconnected)
+            guard let terminatedDict = IOServiceMatching(kIOUSBDeviceClassName) else {
+                throw USBMonitorError.failedToCreateMatchingDictionary
+            }
+
+            let terminatedCallback: IOServiceMatchingCallback = { (refcon, iterator) in
+                let monitor = Unmanaged<IOKitUSBMonitor>.fromOpaque(refcon!).takeUnretainedValue()
+                Task {
+                    await monitor.handleDeviceTerminated(iterator: iterator)
+                }
+            }
+
+            let terminatedResult = IOServiceAddMatchingNotification(
+                notificationPort,
+                kIOTerminatedNotification,
+                terminatedDict,
+                terminatedCallback,
+                selfPtr,
+                &terminatedIterator
+            )
+
+            guard terminatedResult == KERN_SUCCESS else {
+                throw USBMonitorError.failedToRegisterNotification("terminated", terminatedResult)
+            }
+
+            // Consume existing matched devices to arm the notification
+            await consumeExistingDevices(iterator: matchedIterator, isConnection: true)
+            await consumeExistingDevices(iterator: terminatedIterator, isConnection: false)
+
+            isRunning = true
+            logger.info("✅ IOKit USB device monitoring started")
+        }
+
+        func stop() async {
+            guard isRunning else { return }
+
+            logger.info("Stopping IOKit USB device monitoring...")
+
+            // Cancel the monitoring task
+            monitoringTask?.cancel()
+            monitoringTask = nil
+
+            // Clean up IOKit resources
+            if matchedIterator != 0 {
+                IOObjectRelease(matchedIterator)
+                matchedIterator = 0
+            }
+
+            if terminatedIterator != 0 {
+                IOObjectRelease(terminatedIterator)
+                terminatedIterator = 0
+            }
+
+            if let notificationPort = notificationPort {
+                IONotificationPortDestroy(notificationPort)
+                self.notificationPort = nil
+            }
+
+            runLoopSource = nil
+            runLoop = nil
+            isRunning = false
+
+            logger.info("✅ IOKit USB device monitoring stopped")
+        }
+
+        func setDeviceHandler(_ handler: @escaping @Sendable (USBDeviceEvent) -> Void) async {
+            self.deviceHandler = handler
+            logger.debug("USB device handler set")
+        }
+
+        // MARK: - Private Methods
+
+        private func runNotificationLoop() async {
+            logger.debug("Starting IOKit notification run loop...")
+
+            // Use the main run loop since CFRunLoop APIs are not available in async contexts
+            let runLoop = CFRunLoopGetMain()
+            self.runLoop = runLoop
+
+            // Add the notification source to the main run loop
+            if let source = runLoopSource {
+                CFRunLoopAddSource(runLoop, source, CFRunLoopMode.defaultMode)
+                logger.debug("Added IOKit notification source to main run loop")
+            }
+
+            // Keep the task alive to maintain the run loop source
+            while !Task.isCancelled && isRunning {
+                // Just sleep and let the run loop handle notifications
+                try? await Task.sleep(for: .seconds(1))
+            }
+
+            // Remove the source from run loop before exiting
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(runLoop, source, CFRunLoopMode.defaultMode)
+                logger.debug("Removed IOKit notification source from main run loop")
+            }
+
+            logger.debug("IOKit notification run loop ended")
+        }
+
+        private func handleDeviceMatched(iterator: io_iterator_t) async {
+            logger.debug("Handling device matched notifications")
+            await processDeviceIterator(iterator: iterator, isConnection: true)
+        }
+
+        private func handleDeviceTerminated(iterator: io_iterator_t) async {
+            logger.debug("Handling device terminated notifications")
+            await processDeviceIterator(iterator: iterator, isConnection: false)
+        }
+
+        private func consumeExistingDevices(iterator: io_iterator_t, isConnection: Bool) async {
+            // Consume existing devices to arm the notification
+            // Don't process them as events since they're already connected
+            var device: io_service_t
+            repeat {
+                device = IOIteratorNext(iterator)
+                if device != 0 {
+                    IOObjectRelease(device)
+                }
+            } while device != 0
+        }
+
+        private func processDeviceIterator(iterator: io_iterator_t, isConnection: Bool) async {
+            var device: io_service_t
+
+            repeat {
+                device = IOIteratorNext(iterator)
+                if device != 0 {
+                    await processUSBDevice(device: device, isConnection: isConnection)
+                    IOObjectRelease(device)
+                }
+            } while device != 0
+        }
+
+        private func processUSBDevice(device: io_service_t, isConnection: Bool) async {
+            guard let deviceInfo = extractUSBDeviceInfo(from: device) else {
+                return
+            }
+
+            let event: USBDeviceEvent =
+                isConnection ? .connected(deviceInfo) : .disconnected(deviceInfo)
+
+            logger.info(
+                "USB device \(isConnection ? "connected" : "disconnected")",
+                metadata: [
+                    "name": "\(deviceInfo.name)",
+                    "vendorId": "\(deviceInfo.vendorId)",
+                    "productId": "\(deviceInfo.productId)",
+                    "isEdgeOS": "\(deviceInfo.isEdgeOS)",
+                ]
+            )
+
+            // Call the device handler
+            deviceHandler?(event)
+        }
+
+        private func extractUSBDeviceInfo(from device: io_service_t) -> USBDeviceInfo? {
+            // Get device properties
+            var properties: Unmanaged<CFMutableDictionary>?
+            let result = IORegistryEntryCreateCFProperties(
+                device,
+                &properties,
+                kCFAllocatorDefault,
+                0
+            )
+
+            guard result == KERN_SUCCESS, let props = properties?.takeRetainedValue() else {
+                logger.debug("Failed to get device properties")
+                return nil
+            }
+
+            let propsDict = props as NSDictionary
+
+            // Extract vendor ID
+            guard let vendorIdNum = propsDict["idVendor"] as? NSNumber else {
+                logger.debug("No vendor ID found")
+                return nil
+            }
+            let vendorId = String(format: "%04X", vendorIdNum.uint16Value)
+
+            // Extract product ID
+            guard let productIdNum = propsDict["idProduct"] as? NSNumber else {
+                logger.debug("No product ID found")
+                return nil
+            }
+            let productId = String(format: "%04X", productIdNum.uint16Value)
+
+            // Extract device name (try multiple possible keys)
+            let deviceName =
+                (propsDict["USB Product Name"] as? String)
+                ?? (propsDict["kUSBProductString"] as? String)
+                ?? (propsDict["Product Name"] as? String) ?? "Unknown USB Device"
+
+            // Create USBDevice to check if it's EdgeOS
+            let usbDevice = USBDevice(
+                name: deviceName,
+                vendorId: Int(vendorId, radix: 16) ?? 0,
+                productId: Int(productId, radix: 16) ?? 0
+            )
+
+            return USBDeviceInfo(from: usbDevice)
+        }
+    }
+
+    // MARK: - Error Types
+
+    enum USBMonitorError: Error, LocalizedError {
+        case failedToCreateNotificationPort
+        case failedToCreateMatchingDictionary
+        case failedToRegisterNotification(String, kern_return_t)
+
+        var errorDescription: String? {
+            switch self {
+            case .failedToCreateNotificationPort:
+                return "Failed to create IOKit notification port"
+            case .failedToCreateMatchingDictionary:
+                return "Failed to create USB device matching dictionary"
+            case .failedToRegisterNotification(let type, let error):
+                return "Failed to register \(type) notification: \(error)"
+            }
+        }
+    }
+
+#endif  // os(macOS)

--- a/Sources/edge-helper/Services/NetworkInterfaceMonitor.swift
+++ b/Sources/edge-helper/Services/NetworkInterfaceMonitor.swift
@@ -1,0 +1,315 @@
+#if os(macOS)
+
+    import EdgeShared
+    import Foundation
+    import Logging
+    import SystemConfiguration
+
+    /// Protocol for network interface monitoring
+    protocol NetworkInterfaceMonitorProtocol: Actor {
+        func start() async throws
+        func stop() async
+        func setInterfaceHandler(
+            _ handler: @escaping @Sendable (NetworkInterfaceEvent) -> Void
+        ) async
+    }
+
+    /// Event-driven network interface monitor using SystemConfiguration framework
+    /// This monitors for network interface availability changes in real-time
+    actor NetworkInterfaceMonitor: NetworkInterfaceMonitorProtocol {
+        private let logger: Logger
+        private var dynamicStore: SCDynamicStore?
+        private var runLoopSource: CFRunLoopSource?
+        private var isRunning = false
+        private var interfaceHandler: (@Sendable (NetworkInterfaceEvent) -> Void)?
+        private var monitoringTask: Task<Void, Never>?
+        private var knownInterfaces: Set<String> = []
+
+        init(logger: Logger) {
+            self.logger = logger
+        }
+
+        func start() async throws {
+            guard !isRunning else {
+                logger.debug("Network interface monitor already running")
+                return
+            }
+
+            logger.info("Starting network interface monitoring...")
+
+            // Create dynamic store session
+            var context = SCDynamicStoreContext(
+                version: 0,
+                info: Unmanaged.passUnretained(self).toOpaque(),
+                retain: nil,
+                release: nil,
+                copyDescription: nil
+            )
+
+            let callback: SCDynamicStoreCallBack = { (store, changedKeys, info) in
+                guard let info = info else { return }
+                let monitor = Unmanaged<NetworkInterfaceMonitor>.fromOpaque(info)
+                    .takeUnretainedValue()
+
+                // Copy the keys array to avoid data races
+                let keysCopy = (changedKeys as? [String]) ?? []
+
+                Task { @MainActor in
+                    await monitor.handleNetworkChange(changedKeys: keysCopy)
+                }
+            }
+
+            dynamicStore = SCDynamicStoreCreate(
+                kCFAllocatorDefault,
+                "com.edgeos.edge-helper.network-monitor" as CFString,
+                callback,
+                &context
+            )
+
+            guard let dynamicStore = dynamicStore else {
+                throw NetworkInterfaceMonitorError.failedToCreateDynamicStore
+            }
+
+            // Set up notification keys - monitor all network interfaces
+            let notificationKeys =
+                [
+                    "State:/Network/Interface" as CFString
+                ] as CFArray
+
+            let notificationPatterns =
+                [
+                    "State:/Network/Interface/.*/Link" as CFString,
+                    "State:/Network/Interface/.*/IPv4" as CFString,
+                ] as CFArray
+
+            let setKeysResult = SCDynamicStoreSetNotificationKeys(
+                dynamicStore,
+                notificationKeys,
+                notificationPatterns
+            )
+
+            guard setKeysResult else {
+                throw NetworkInterfaceMonitorError.failedToSetNotificationKeys
+            }
+
+            // Create run loop source
+            runLoopSource = SCDynamicStoreCreateRunLoopSource(
+                kCFAllocatorDefault,
+                dynamicStore,
+                0
+            )
+
+            guard runLoopSource != nil else {
+                throw NetworkInterfaceMonitorError.failedToCreateRunLoopSource
+            }
+
+            // Get initial state of interfaces
+            await loadInitialInterfaceState()
+
+            // Start the run loop monitoring task
+            monitoringTask = Task {
+                await withTaskCancellationHandler {
+                    await runNotificationLoop()
+                } onCancel: {
+                    // Cleanup will be handled in stop()
+                }
+            }
+
+            isRunning = true
+            logger.info("✅ Network interface monitoring started")
+        }
+
+        func stop() async {
+            guard isRunning else { return }
+
+            logger.info("Stopping network interface monitoring...")
+
+            // Cancel monitoring task
+            monitoringTask?.cancel()
+            monitoringTask = nil
+
+            // Clean up SystemConfiguration resources
+            if let runLoopSource = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, CFRunLoopMode.defaultMode)
+                self.runLoopSource = nil
+            }
+
+            if let dynamicStore = dynamicStore {
+                SCDynamicStoreSetNotificationKeys(dynamicStore, nil, nil)
+                self.dynamicStore = nil
+            }
+
+            knownInterfaces.removeAll()
+            isRunning = false
+
+            logger.info("✅ Network interface monitoring stopped")
+        }
+
+        func setInterfaceHandler(
+            _ handler: @escaping @Sendable (NetworkInterfaceEvent) -> Void
+        ) async {
+            self.interfaceHandler = handler
+            logger.debug("Network interface handler set")
+        }
+
+        // MARK: - Private Methods
+
+        private func runNotificationLoop() async {
+            logger.debug("Starting network interface notification run loop...")
+
+            // Add the notification source to the main run loop
+            if let source = runLoopSource {
+                CFRunLoopAddSource(CFRunLoopGetMain(), source, CFRunLoopMode.defaultMode)
+                logger.debug("Added network interface notification source to main run loop")
+            }
+
+            // Keep the task alive to maintain the run loop source
+            while !Task.isCancelled && isRunning {
+                try? await Task.sleep(for: .seconds(1))
+            }
+
+            logger.debug("Network interface notification run loop ended")
+        }
+
+        private func loadInitialInterfaceState() async {
+            guard let dynamicStore = dynamicStore else { return }
+
+            // Get list of current network interfaces
+            let interfaceListKey = "State:/Network/Interface" as CFString
+            if let interfaceList = SCDynamicStoreCopyValue(dynamicStore, interfaceListKey)
+                as? [String]
+            {
+                knownInterfaces = Set(interfaceList)
+                logger.debug("Initial network interfaces: \(knownInterfaces)")
+            }
+        }
+
+        private func handleNetworkChange(changedKeys: [String]) async {
+            logger.debug("Network change detected for keys: \(changedKeys)")
+
+            guard let dynamicStore = dynamicStore else { return }
+
+            // Check for interface additions/removals
+            await checkForInterfaceChanges()
+
+            // Check for EdgeOS interface events specifically
+            for key in changedKeys {
+                if key.contains("/Link") {
+                    await handleLinkStatusChange(key: key, dynamicStore: dynamicStore)
+                } else if key.contains("/IPv4") {
+                    await handleIPv4Change(key: key, dynamicStore: dynamicStore)
+                }
+            }
+        }
+
+        private func checkForInterfaceChanges() async {
+            guard let dynamicStore = dynamicStore else { return }
+
+            // Get current interface list
+            let interfaceListKey = "State:/Network/Interface" as CFString
+            guard
+                let currentInterfaces = SCDynamicStoreCopyValue(dynamicStore, interfaceListKey)
+                    as? [String]
+            else {
+                return
+            }
+
+            let currentSet = Set(currentInterfaces)
+
+            // Find new interfaces
+            let newInterfaces = currentSet.subtracting(knownInterfaces)
+            for interface in newInterfaces {
+                await checkIfEdgeOSInterface(interface: interface, isAppearing: true)
+            }
+
+            // Find removed interfaces
+            let removedInterfaces = knownInterfaces.subtracting(currentSet)
+            for interface in removedInterfaces {
+                await notifyInterfaceRemoved(interface: interface)
+            }
+
+            knownInterfaces = currentSet
+        }
+
+        private func handleLinkStatusChange(key: String, dynamicStore: SCDynamicStore) async {
+            // Extract interface name from key like "State:/Network/Interface/en5/Link"
+            let components = key.components(separatedBy: "/")
+            guard components.count >= 4 else { return }
+
+            let interfaceName = components[3]
+
+            // Check if this is an EdgeOS interface and if link is up
+            if let linkInfo = SCDynamicStoreCopyValue(dynamicStore, key as CFString)
+                as? [String: Any],
+                let linkStatus = linkInfo["Active"] as? Bool,
+                linkStatus
+            {
+
+                await checkIfEdgeOSInterface(interface: interfaceName, isAppearing: true)
+            }
+        }
+
+        private func handleIPv4Change(key: String, dynamicStore: SCDynamicStore) async {
+            // Extract interface name from key like "State:/Network/Interface/en5/IPv4"
+            let components = key.components(separatedBy: "/")
+            guard components.count >= 4 else { return }
+
+            let interfaceName = components[3]
+
+            // Check if IPv4 configuration appeared (interface became ready)
+            if SCDynamicStoreCopyValue(dynamicStore, key as CFString) != nil {
+                await checkIfEdgeOSInterface(interface: interfaceName, isAppearing: true)
+            }
+        }
+
+        private func checkIfEdgeOSInterface(interface: String, isAppearing: Bool) async {
+            // For interface appearance events, we check if it's an Ethernet interface that could be EdgeOS
+            // We can't rely on the interface name containing "EdgeOS" because the system assigns
+            // generic names like en5, en6, etc. Instead, we trigger for any Ethernet interface
+            // and let the daemon correlate it with pending USB devices.
+
+            if interface.hasPrefix("en") || interface.hasPrefix("eth") {
+                let event: NetworkInterfaceEvent =
+                    isAppearing ? .interfaceAppeared(interface) : .interfaceDisappeared(interface)
+
+                logger.info(
+                    "Ethernet interface \(isAppearing ? "appeared" : "disappeared"): \(interface)"
+                )
+                interfaceHandler?(event)
+            }
+        }
+
+        private func notifyInterfaceRemoved(interface: String) async {
+            let event: NetworkInterfaceEvent = .interfaceDisappeared(interface)
+            logger.info("Network interface disappeared: \(interface)")
+            interfaceHandler?(event)
+        }
+    }
+
+    // MARK: - Event Types
+
+    enum NetworkInterfaceEvent {
+        case interfaceAppeared(String)  // Interface name (e.g., "en5")
+        case interfaceDisappeared(String)  // Interface name (e.g., "en5")
+    }
+
+    // MARK: - Error Types
+
+    enum NetworkInterfaceMonitorError: Error, LocalizedError {
+        case failedToCreateDynamicStore
+        case failedToSetNotificationKeys
+        case failedToCreateRunLoopSource
+
+        var errorDescription: String? {
+            switch self {
+            case .failedToCreateDynamicStore:
+                return "Failed to create SystemConfiguration dynamic store"
+            case .failedToSetNotificationKeys:
+                return "Failed to set network interface notification keys"
+            case .failedToCreateRunLoopSource:
+                return "Failed to create run loop source for network monitoring"
+            }
+        }
+    }
+
+#endif  // os(macOS)

--- a/Sources/edge-helper/Services/SystemConfigurationService.swift
+++ b/Sources/edge-helper/Services/SystemConfigurationService.swift
@@ -1,0 +1,95 @@
+#if os(macOS)
+
+    import Foundation
+    import SystemConfiguration
+
+    /// Protocol for abstracting SystemConfiguration operations to enable testing
+    protocol SystemConfigurationServiceProtocol {
+        /// Creates a SystemConfiguration dynamic store
+        func createDynamicStore(
+            name: CFString,
+            callback: SCDynamicStoreCallBack?,
+            context: UnsafeMutablePointer<SCDynamicStoreContext>?
+        ) -> SCDynamicStore?
+
+        /// Sets notification keys for the dynamic store
+        func setNotificationKeys(
+            store: SCDynamicStore,
+            keys: CFArray?,
+            patterns: CFArray?
+        ) -> Bool
+
+        /// Creates a run loop source for the dynamic store
+        func createRunLoopSource(
+            store: SCDynamicStore,
+            order: CFIndex
+        ) -> CFRunLoopSource?
+
+        /// Copies a value from the dynamic store
+        func copyValue(
+            store: SCDynamicStore,
+            key: CFString
+        ) -> CFPropertyList?
+
+        /// Adds a run loop source to the main run loop
+        func addRunLoopSource(
+            source: CFRunLoopSource,
+            mode: CFRunLoopMode
+        )
+
+        /// Removes a run loop source from the main run loop
+        func removeRunLoopSource(
+            source: CFRunLoopSource,
+            mode: CFRunLoopMode
+        )
+    }
+
+    /// Real implementation that wraps actual SystemConfiguration APIs
+    struct RealSystemConfigurationService: SystemConfigurationServiceProtocol {
+
+        func createDynamicStore(
+            name: CFString,
+            callback: SCDynamicStoreCallBack?,
+            context: UnsafeMutablePointer<SCDynamicStoreContext>?
+        ) -> SCDynamicStore? {
+            return SCDynamicStoreCreate(kCFAllocatorDefault, name, callback, context)
+        }
+
+        func setNotificationKeys(
+            store: SCDynamicStore,
+            keys: CFArray?,
+            patterns: CFArray?
+        ) -> Bool {
+            return SCDynamicStoreSetNotificationKeys(store, keys, patterns)
+        }
+
+        func createRunLoopSource(
+            store: SCDynamicStore,
+            order: CFIndex
+        ) -> CFRunLoopSource? {
+            return SCDynamicStoreCreateRunLoopSource(kCFAllocatorDefault, store, order)
+        }
+
+        func copyValue(
+            store: SCDynamicStore,
+            key: CFString
+        ) -> CFPropertyList? {
+            return SCDynamicStoreCopyValue(store, key)
+        }
+
+        func addRunLoopSource(
+            source: CFRunLoopSource,
+            mode: CFRunLoopMode
+        ) {
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, mode)
+        }
+
+        func removeRunLoopSource(
+            source: CFRunLoopSource,
+            mode: CFRunLoopMode
+        ) {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, mode)
+        }
+    }
+
+#endif  // os(macOS)

--- a/Sources/edge-helper/Services/USBDeviceInfoExtractor.swift
+++ b/Sources/edge-helper/Services/USBDeviceInfoExtractor.swift
@@ -1,0 +1,54 @@
+#if os(macOS)
+
+    import Foundation
+    import IOKit
+    import IOKit.usb
+    import Logging
+    import EdgeShared
+
+    /// Protocol for extracting USB device information from properties
+    protocol USBDeviceInfoExtractorProtocol {
+        func extractUSBDeviceInfo(from properties: [String: Any]) -> USBDeviceInfo?
+    }
+
+    /// Extracts USB device information from IOKit properties
+    struct USBDeviceInfoExtractor: USBDeviceInfoExtractorProtocol {
+        private let logger: Logger
+
+        init(logger: Logger) {
+            self.logger = logger
+        }
+
+        func extractUSBDeviceInfo(from properties: [String: Any]) -> USBDeviceInfo? {
+            // Extract vendor ID
+            guard let vendorIdNum = properties["idVendor"] as? NSNumber else {
+                logger.debug("No vendor ID found")
+                return nil
+            }
+            let vendorId = String(format: "%04X", vendorIdNum.uint16Value)
+
+            // Extract product ID
+            guard let productIdNum = properties["idProduct"] as? NSNumber else {
+                logger.debug("No product ID found")
+                return nil
+            }
+            let productId = String(format: "%04X", productIdNum.uint16Value)
+
+            // Extract device name (try multiple possible keys)
+            let deviceName =
+                (properties["USB Product Name"] as? String)
+                ?? (properties["kUSBProductString"] as? String)
+                ?? (properties["Product Name"] as? String) ?? "Unknown USB Device"
+
+            // Create USBDevice to check if it's EdgeOS
+            let usbDevice = USBDevice(
+                name: deviceName,
+                vendorId: Int(vendorId, radix: 16) ?? 0,
+                productId: Int(productId, radix: 16) ?? 0
+            )
+
+            return USBDeviceInfo(from: usbDevice)
+        }
+    }
+
+#endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/IOKitUSBMonitorMockTests.swift
+++ b/Tests/EdgeHelperMacOSTests/IOKitUSBMonitorMockTests.swift
@@ -1,0 +1,430 @@
+#if os(macOS)
+    import EdgeShared
+    import Foundation
+    import Logging
+    import Testing
+
+    @testable import edge_helper
+
+    /// Thread-safe event collector for testing
+    final class EventCollector: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _events: [USBDeviceEvent] = []
+
+        func append(_ event: USBDeviceEvent) {
+            lock.lock()
+            defer { lock.unlock() }
+            _events.append(event)
+        }
+
+        var events: [USBDeviceEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return _events
+        }
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _events.count
+        }
+
+        func clear() {
+            lock.lock()
+            defer { lock.unlock() }
+            _events.removeAll()
+        }
+    }
+
+    @Suite("IOKit USB Monitor Mock Tests")
+    struct IOKitUSBMonitorMockTests {
+
+        private func createTestLogger() -> Logger {
+            return Logger(label: "test.iokit.usb.monitor.mock")
+        }
+
+        @Test("Full device detection pipeline with EdgeOS device")
+        func testFullEdgeOSDeviceDetectionPipeline() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Simulate EdgeOS device connection - this tests the FULL pipeline:
+            // MockIOKit → handleDeviceMatched → processDeviceIterator →
+            // processUSBDevice → extractUSBDeviceInfo → deviceHandler callback
+            let edgeOSDevice = MockDevice(
+                vendorId: 0x1D6B,  // EdgeOS vendor ID
+                productId: 0x0104,  // EdgeOS product ID
+                name: "EdgeOS Test Device"
+            )
+            mockIOKit.simulateDeviceConnection(edgeOSDevice)
+
+            // Give callbacks time to process
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Verify the callback was invoked with the correct event
+            #expect(eventCollector.count == 1)
+            if case .connected(let deviceInfo) = eventCollector.events.first {
+                #expect(deviceInfo.isEdgeOS == true)
+                #expect(deviceInfo.name == "EdgeOS Test Device")
+                #expect(deviceInfo.vendorId == "0x1D6B")
+                #expect(deviceInfo.productId == "0x0104")
+            } else {
+                #expect(Bool(false), "Expected connected event")
+            }
+        }
+
+        @Test("Full device detection pipeline with non-EdgeOS device")
+        func testFullNonEdgeOSDeviceDetectionPipeline() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Simulate non-EdgeOS device connection
+            let nonEdgeOSDevice = MockDevice(
+                vendorId: 0x05AC,  // Apple vendor ID
+                productId: 0x12A8,
+                name: "Apple Keyboard"
+            )
+            mockIOKit.simulateDeviceConnection(nonEdgeOSDevice)
+
+            // Give callbacks time to process
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Verify the callback was invoked with the correct event
+            #expect(eventCollector.count == 1)
+            if case .connected(let deviceInfo) = eventCollector.events.first {
+                #expect(deviceInfo.isEdgeOS == false)
+                #expect(deviceInfo.name == "Apple Keyboard")
+                #expect(deviceInfo.vendorId == "0x05AC")
+                #expect(deviceInfo.productId == "0x12A8")
+            } else {
+                #expect(Bool(false), "Expected connected event")
+            }
+        }
+
+        @Test("Device disconnection pipeline")
+        func testDeviceDisconnectionPipeline() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            let device = MockDevice(
+                vendorId: 0x1D6B,
+                productId: 0x0104,
+                name: "EdgeOS Device"
+            )
+
+            // First connect the device
+            mockIOKit.simulateDeviceConnection(device)
+            try await Task.sleep(for: .milliseconds(50))
+
+            // Then disconnect it
+            mockIOKit.simulateDeviceDisconnection(device)
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Should have both connection and disconnection events
+            #expect(eventCollector.count == 2)
+
+            // Verify connection event
+            if case .connected(let deviceInfo) = eventCollector.events[0] {
+                #expect(deviceInfo.name == "EdgeOS Device")
+            } else {
+                #expect(Bool(false), "Expected connected event first")
+            }
+
+            // Verify disconnection event
+            if case .disconnected(let deviceInfo) = eventCollector.events[1] {
+                #expect(deviceInfo.name == "EdgeOS Device")
+            } else {
+                #expect(Bool(false), "Expected disconnected event second")
+            }
+        }
+
+        @Test("Multiple device connections")
+        func testMultipleDeviceConnections() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Connect multiple devices
+            let devices = [
+                MockDevice(vendorId: 0x1D6B, productId: 0x0104, name: "EdgeOS Device 1"),
+                MockDevice(vendorId: 0x1D6B, productId: 0x0105, name: "EdgeOS Device 2"),
+                MockDevice(vendorId: 0x05AC, productId: 0x12A8, name: "Apple Device"),
+            ]
+
+            await mockIOKit.simulateMultipleDeviceConnections(devices)
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Should receive events for all devices
+            #expect(eventCollector.count == 3)
+
+            let deviceNames = eventCollector.events.compactMap { event in
+                if case .connected(let deviceInfo) = event {
+                    return deviceInfo.name
+                }
+                return nil
+            }
+
+            #expect(deviceNames.contains("EdgeOS Device 1"))
+            #expect(deviceNames.contains("EdgeOS Device 2"))
+            #expect(deviceNames.contains("Apple Device"))
+        }
+
+        @Test("Device properties extraction integration")
+        func testDevicePropertiesExtractionIntegration() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Test device with specific properties that should be extracted correctly
+            let device = MockDevice(
+                vendorId: 0x000A,  // Low value to test hex formatting
+                productId: 0x00BC,
+                name: "Test Device with Special Properties"
+            )
+            mockIOKit.simulateDeviceConnection(device)
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            #expect(eventCollector.count == 1)
+            if case .connected(let deviceInfo) = eventCollector.events.first {
+                // Test that hex formatting is correct (should be padded)
+                #expect(deviceInfo.vendorId == "0x000A")
+                #expect(deviceInfo.productId == "0x00BC")
+                #expect(deviceInfo.name == "Test Device with Special Properties")
+                #expect(deviceInfo.id == "0x000A:0x00BC")
+            } else {
+                #expect(Bool(false), "Expected connected event")
+            }
+        }
+
+        @Test("Custom device info extractor integration")
+        func testCustomDeviceInfoExtractorIntegration() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            var mockExtractor = MockUSBDeviceInfoExtractor()
+
+            // Configure the mock extractor to return a specific device
+            let customDevice = USBDeviceInfo(
+                from: USBDevice(
+                    name: "Custom Extracted Device",
+                    vendorId: 0x9999,
+                    productId: 0x8888
+                )
+            )
+            mockExtractor.deviceInfoToReturn = customDevice
+
+            let monitor = IOKitUSBMonitor(
+                logger: logger,
+                deviceInfoExtractor: mockExtractor,
+                ioKitService: mockIOKit
+            )
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Simulate any device connection - the mock extractor will override the properties
+            let anyDevice = MockDevice(vendorId: 0x1234, productId: 0x5678, name: "Original Device")
+            mockIOKit.simulateDeviceConnection(anyDevice)
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Verify that the custom extractor was used
+            #expect(eventCollector.count == 1)
+            if case .connected(let deviceInfo) = eventCollector.events.first {
+                #expect(deviceInfo.name == "Custom Extracted Device")
+                #expect(deviceInfo.vendorId == "0x9999")
+                #expect(deviceInfo.productId == "0x8888")
+            } else {
+                #expect(Bool(false), "Expected connected event")
+            }
+        }
+
+        @Test("Failed device info extraction")
+        func testFailedDeviceInfoExtraction() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            var mockExtractor = MockUSBDeviceInfoExtractor()
+
+            // Configure the mock extractor to fail
+            mockExtractor.shouldReturnNil = true
+
+            let monitor = IOKitUSBMonitor(
+                logger: logger,
+                deviceInfoExtractor: mockExtractor,
+                ioKitService: mockIOKit
+            )
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Simulate device connection with extraction failure
+            let device = MockDevice(vendorId: 0x1234, productId: 0x5678, name: "Device")
+            mockIOKit.simulateDeviceConnection(device)
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Should receive no events because extraction failed
+            #expect(eventCollector.count == 0)
+        }
+
+        @Test("IOKit service failure handling")
+        func testIOKitServiceFailureHandling() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+
+            // Configure mock to fail various operations
+            mockIOKit.setAllFailures(true)
+
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            // Starting should fail due to mock failures
+            do {
+                try await monitor.start()
+                #expect(Bool(false), "Expected start to fail")
+            } catch {
+                // Expected to fail
+                #expect(error is USBMonitorError)
+            }
+        }
+
+        @Test("Handler replacement with mock service")
+        func testHandlerReplacementWithMockService() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let firstHandlerEvents = EventCollector()
+            let secondHandlerEvents = EventCollector()
+
+            try await monitor.start()
+
+            // Set first handler
+            await monitor.setDeviceHandler { event in
+                firstHandlerEvents.append(event)
+            }
+
+            // Trigger event for first handler
+            let device1 = MockDevice(vendorId: 0x1111, productId: 0x2222, name: "Device 1")
+            mockIOKit.simulateDeviceConnection(device1)
+            try await Task.sleep(for: .milliseconds(50))
+
+            // Replace with second handler
+            await monitor.setDeviceHandler { event in
+                secondHandlerEvents.append(event)
+            }
+
+            // Trigger event for second handler
+            let device2 = MockDevice(vendorId: 0x3333, productId: 0x4444, name: "Device 2")
+            mockIOKit.simulateDeviceConnection(device2)
+            try await Task.sleep(for: .milliseconds(50))
+
+            await monitor.stop()
+
+            // Verify handler replacement worked
+            #expect(firstHandlerEvents.count == 1)
+            #expect(secondHandlerEvents.count == 1)
+
+            if case .connected(let deviceInfo) = firstHandlerEvents.events.first {
+                #expect(deviceInfo.name == "Device 1")
+            }
+
+            if case .connected(let deviceInfo) = secondHandlerEvents.events.first {
+                #expect(deviceInfo.name == "Device 2")
+            }
+        }
+
+        @Test("Concurrent device events with mock service")
+        func testConcurrentDeviceEventsWithMockService() async throws {
+            let logger = createTestLogger()
+            let mockIOKit = MockIOKitService()
+            let monitor = IOKitUSBMonitor(logger: logger, ioKitService: mockIOKit)
+
+            let eventCollector = EventCollector()
+            await monitor.setDeviceHandler { event in
+                eventCollector.append(event)
+            }
+
+            try await monitor.start()
+
+            // Simulate concurrent device connections
+            await withTaskGroup(of: Void.self) { group in
+                for i in 0..<5 {
+                    group.addTask {
+                        let device = MockDevice(
+                            vendorId: UInt16(0x1000 + i),
+                            productId: UInt16(0x2000 + i),
+                            name: "Concurrent Device \(i)"
+                        )
+                        mockIOKit.simulateDeviceConnection(device)
+                    }
+                }
+            }
+
+            // Wait for all events to be processed
+            try await Task.sleep(for: .milliseconds(100))
+
+            await monitor.stop()
+
+            // Should receive all 5 events
+            #expect(eventCollector.count == 5)
+        }
+    }
+
+#endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/IOKitUSBMonitorTests.swift
+++ b/Tests/EdgeHelperMacOSTests/IOKitUSBMonitorTests.swift
@@ -1,0 +1,68 @@
+#if os(macOS)
+    import EdgeShared
+    import Foundation
+    import Logging
+    import Testing
+
+    @testable import edge_helper
+
+    @Suite("IOKit USB Monitor Tests")
+    struct IOKitUSBMonitorTests {
+
+        private func createTestLogger() -> Logger {
+            return Logger(label: "test.iokit.usb.monitor")
+        }
+
+        @Test("IOKit USB monitor can start and stop")
+        func testStartStop() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Test starting
+            try await monitor.start()
+
+            // Test stopping
+            await monitor.stop()
+
+            // Should be able to start/stop multiple times
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor can set device handler")
+        func testSetDeviceHandler() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            await monitor.setDeviceHandler { event in
+                // Handler is set (we can't easily test it fires without real hardware)
+                // This test mainly verifies the interface works correctly
+            }
+        }
+
+        @Test("IOKit USB monitor handles start failures gracefully")
+        func testStartFailureHandling() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Start should work normally
+            try await monitor.start()
+
+            // Starting again should not throw (should handle already running case)
+            try await monitor.start()
+
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor handles stop on non-running monitor")
+        func testStopNonRunning() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Should not crash when stopping a non-running monitor
+            await monitor.stop()
+            await monitor.stop()  // Multiple stops should be safe
+        }
+    }
+
+#endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/IOKitUSBMonitorTests.swift
+++ b/Tests/EdgeHelperMacOSTests/IOKitUSBMonitorTests.swift
@@ -63,6 +63,173 @@
             await monitor.stop()
             await monitor.stop()  // Multiple stops should be safe
         }
+
+        @Test("IOKit USB monitor with custom device info extractor")
+        func testWithCustomDeviceInfoExtractor() async throws {
+            let logger = createTestLogger()
+            let mockExtractor = MockUSBDeviceInfoExtractor()
+            let monitor = IOKitUSBMonitor(logger: logger, deviceInfoExtractor: mockExtractor)
+
+            // Test that monitor can be created with custom extractor
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor device handler invocation")
+        func testDeviceHandlerInvocation() async throws {
+            let logger = createTestLogger()
+
+            var mockExtractor = MockUSBDeviceInfoExtractor()
+            let testDevice = USBDeviceInfo(
+                from: USBDevice(
+                    name: "Test EdgeOS Device",
+                    vendorId: 0x1D6B,
+                    productId: 0x0104
+                )
+            )
+            mockExtractor.deviceInfoToReturn = testDevice
+
+            let monitor = IOKitUSBMonitor(logger: logger, deviceInfoExtractor: mockExtractor)
+
+            // Set device handler
+            await monitor.setDeviceHandler { event in
+                // Handler is set - we can't easily test event delivery without real hardware
+                // This test mainly verifies that the handler can be set without crashing
+            }
+
+            // Since we can't easily trigger real IOKit events, this test mainly verifies
+            // that the handler can be set and the monitor can start/stop with it
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor state management")
+        func testStateManagement() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Monitor should start as not running
+            // Note: We can't directly access isRunning as it's private,
+            // but we can test behavior
+
+            // First start should succeed
+            try await monitor.start()
+
+            // Second start should be idempotent (not throw)
+            try await monitor.start()
+
+            // Stop should work
+            await monitor.stop()
+
+            // Multiple stops should be safe
+            await monitor.stop()
+            await monitor.stop()
+
+            // Should be able to restart after stopping
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor handler replacement")
+        func testHandlerReplacement() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Set initial handler
+            await monitor.setDeviceHandler { _ in
+                // Initial handler
+            }
+
+            // Replace with new handler
+            await monitor.setDeviceHandler { _ in
+                // Replacement handler
+            }
+
+            // Set nil handler (should not crash)
+            await monitor.setDeviceHandler { _ in
+                // Another handler
+            }
+
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor with failing extractor")
+        func testWithFailingExtractor() async throws {
+            let logger = createTestLogger()
+            var mockExtractor = MockUSBDeviceInfoExtractor()
+            mockExtractor.shouldReturnNil = true  // Simulate extraction failure
+
+            let monitor = IOKitUSBMonitor(logger: logger, deviceInfoExtractor: mockExtractor)
+
+            await monitor.setDeviceHandler { event in
+                // This handler should not be called due to failing extractor
+            }
+
+            try await monitor.start()
+
+            // Even with failing extractor, monitor should start successfully
+            // Real device events would be filtered out by the failing extractor
+
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor resource cleanup")
+        func testResourceCleanup() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Test multiple start/stop cycles to ensure proper cleanup
+            for _ in 0..<3 {
+                try await monitor.start()
+
+                // Set a handler during each cycle
+                await monitor.setDeviceHandler { _ in
+                    // Handler
+                }
+
+                await monitor.stop()
+            }
+
+            // Final start/stop
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("IOKit USB monitor concurrent operations")
+        func testConcurrentOperations() async throws {
+            let logger = createTestLogger()
+            let monitor = IOKitUSBMonitor(logger: logger)
+
+            // Test concurrent start operations
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<5 {
+                    group.addTask {
+                        try? await monitor.start()
+                    }
+                }
+            }
+
+            // Test concurrent handler setting
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<3 {
+                    group.addTask {
+                        await monitor.setDeviceHandler { _ in
+                            // Handler
+                        }
+                    }
+                }
+            }
+
+            // Test concurrent stop operations
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<5 {
+                    group.addTask {
+                        await monitor.stop()
+                    }
+                }
+            }
+        }
     }
 
 #endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/NetworkInterfaceMonitorTests.swift
+++ b/Tests/EdgeHelperMacOSTests/NetworkInterfaceMonitorTests.swift
@@ -1,0 +1,68 @@
+#if os(macOS)
+    import EdgeShared
+    import Foundation
+    import Logging
+    import Testing
+
+    @testable import edge_helper
+
+    @Suite("Network Interface Monitor Tests")
+    struct NetworkInterfaceMonitorTests {
+
+        private func createTestLogger() -> Logger {
+            return Logger(label: "test.network.interface.monitor")
+        }
+
+        @Test("Network interface monitor can start and stop")
+        func testStartStop() async throws {
+            let logger = createTestLogger()
+            let monitor = NetworkInterfaceMonitor(logger: logger)
+
+            // Test starting
+            try await monitor.start()
+
+            // Test stopping
+            await monitor.stop()
+
+            // Should be able to start/stop multiple times
+            try await monitor.start()
+            await monitor.stop()
+        }
+
+        @Test("Network interface monitor can set interface handler")
+        func testSetInterfaceHandler() async throws {
+            let logger = createTestLogger()
+            let monitor = NetworkInterfaceMonitor(logger: logger)
+
+            await monitor.setInterfaceHandler { event in
+                // Handler is set (we can't easily test it fires without real hardware)
+                // This test mainly verifies the interface works correctly
+            }
+        }
+
+        @Test("Network interface monitor handles start failures gracefully")
+        func testStartFailureHandling() async throws {
+            let logger = createTestLogger()
+            let monitor = NetworkInterfaceMonitor(logger: logger)
+
+            // Start should work normally
+            try await monitor.start()
+
+            // Starting again should not throw (should handle already running case)
+            try await monitor.start()
+
+            await monitor.stop()
+        }
+
+        @Test("Network interface monitor handles stop on non-running monitor")
+        func testStopNonRunning() async throws {
+            let logger = createTestLogger()
+            let monitor = NetworkInterfaceMonitor(logger: logger)
+
+            // Should not crash when stopping a non-running monitor
+            await monitor.stop()
+            await monitor.stop()  // Multiple stops should be safe
+        }
+    }
+
+#endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/USBDeviceInfoExtractorTests.swift
+++ b/Tests/EdgeHelperMacOSTests/USBDeviceInfoExtractorTests.swift
@@ -1,0 +1,201 @@
+#if os(macOS)
+    import EdgeShared
+    import Foundation
+    import Logging
+    import Testing
+
+    @testable import edge_helper
+
+    @Suite("USB Device Info Extractor Tests")
+    struct USBDeviceInfoExtractorTests {
+
+        private func createTestLogger() -> Logger {
+            return Logger(label: "test.usb.device.info.extractor")
+        }
+
+        @Test("Extract EdgeOS device info from valid properties")
+        func testExtractEdgeOSDeviceInfo() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            // Create test properties for EdgeOS device
+            let properties: [String: Any] = [
+                "idVendor": NSNumber(value: 0x1D6B),  // EdgeOS vendor ID
+                "idProduct": NSNumber(value: 0x0104),  // EdgeOS product ID
+                "USB Product Name": "EdgeOS Device",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+
+            // Verify device info
+            #expect(deviceInfo != nil)
+            #expect(deviceInfo?.vendorId == "0x1D6B")
+            #expect(deviceInfo?.productId == "0x0104")
+            #expect(deviceInfo?.name == "EdgeOS Device")
+            #expect(deviceInfo?.isEdgeOS == true)
+        }
+
+        @Test("Extract non-EdgeOS device info")
+        func testExtractNonEdgeOSDeviceInfo() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            // Create test properties for non-EdgeOS device
+            let properties: [String: Any] = [
+                "idVendor": NSNumber(value: 0x05AC),  // Apple vendor ID
+                "idProduct": NSNumber(value: 0x12A8),  // Some Apple product
+                "USB Product Name": "Apple Keyboard",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+
+            // Verify device info
+            #expect(deviceInfo != nil)
+            #expect(deviceInfo?.vendorId == "0x05AC")
+            #expect(deviceInfo?.productId == "0x12A8")
+            #expect(deviceInfo?.name == "Apple Keyboard")
+            #expect(deviceInfo?.isEdgeOS == false)
+        }
+
+        @Test("Handle different device name keys")
+        func testDifferentDeviceNameKeys() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            // Test with kUSBProductString
+            var properties: [String: Any] = [
+                "idVendor": NSNumber(value: 0x1234),
+                "idProduct": NSNumber(value: 0x5678),
+                "kUSBProductString": "USB Device with kUSBProductString",
+            ]
+
+            var deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo?.name == "USB Device with kUSBProductString")
+
+            // Test with Product Name
+            properties = [
+                "idVendor": NSNumber(value: 0x1234),
+                "idProduct": NSNumber(value: 0x5678),
+                "Product Name": "USB Device with Product Name",
+            ]
+
+            deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo?.name == "USB Device with Product Name")
+
+            // Test with no name - should use default
+            properties = [
+                "idVendor": NSNumber(value: 0x1234),
+                "idProduct": NSNumber(value: 0x5678),
+            ]
+
+            deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo?.name == "Unknown USB Device")
+        }
+
+        @Test("Handle missing vendor ID")
+        func testMissingVendorId() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            let properties: [String: Any] = [
+                // Missing idVendor
+                "idProduct": NSNumber(value: 0x5678),
+                "USB Product Name": "Test Device",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo == nil)
+        }
+
+        @Test("Handle missing product ID")
+        func testMissingProductId() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            let properties: [String: Any] = [
+                "idVendor": NSNumber(value: 0x1234),
+                // Missing idProduct
+                "USB Product Name": "Test Device",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo == nil)
+        }
+
+        @Test("Handle invalid vendor/product ID types")
+        func testInvalidIdTypes() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            // Test with string instead of NSNumber
+            let properties: [String: Any] = [
+                "idVendor": "1234",  // Should be NSNumber
+                "idProduct": "5678",  // Should be NSNumber
+                "USB Product Name": "Test Device",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo == nil)
+        }
+
+        @Test("Verify hex formatting of IDs")
+        func testHexFormattingOfIds() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            // Test with small values that need padding
+            let properties: [String: Any] = [
+                "idVendor": NSNumber(value: 0x000A),  // Should format as "0x000A"
+                "idProduct": NSNumber(value: 0x00BC),  // Should format as "0x00BC"
+                "USB Product Name": "Test Device",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo != nil)
+            #expect(deviceInfo?.vendorId == "0x000A")
+            #expect(deviceInfo?.productId == "0x00BC")
+
+            // Verify the ID is constructed correctly (from USBDevice init)
+            #expect(deviceInfo?.id == "0x000A:0x00BC")
+        }
+
+        @Test("Test priority of device name keys")
+        func testDeviceNameKeyPriority() {
+            let logger = createTestLogger()
+            let extractor = USBDeviceInfoExtractor(logger: logger)
+
+            // When all keys are present, USB Product Name should be used first
+            let properties: [String: Any] = [
+                "idVendor": NSNumber(value: 0x1234),
+                "idProduct": NSNumber(value: 0x5678),
+                "USB Product Name": "Priority 1",
+                "kUSBProductString": "Priority 2",
+                "Product Name": "Priority 3",
+            ]
+
+            let deviceInfo = extractor.extractUSBDeviceInfo(from: properties)
+            #expect(deviceInfo?.name == "Priority 1")
+        }
+    }
+
+    // Mock implementation for testing
+    struct MockUSBDeviceInfoExtractor: USBDeviceInfoExtractorProtocol {
+        var shouldReturnNil = false
+        var deviceInfoToReturn: USBDeviceInfo?
+
+        func extractUSBDeviceInfo(from properties: [String: Any]) -> USBDeviceInfo? {
+            if shouldReturnNil {
+                return nil
+            }
+            return deviceInfoToReturn
+                ?? USBDeviceInfo(
+                    from: USBDevice(
+                        name: "Mock Device",
+                        vendorId: 0x1234,
+                        productId: 0x5678
+                    )
+                )
+        }
+    }
+
+#endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/mocks/MockIOKitService.swift
+++ b/Tests/EdgeHelperMacOSTests/mocks/MockIOKitService.swift
@@ -1,0 +1,280 @@
+#if os(macOS)
+
+    import Foundation
+    import IOKit
+    import IOKit.usb
+    import IOKit.usb.IOUSBLib
+    import Logging
+
+    @testable import edge_helper
+
+    /// Mock device data for testing
+    struct MockDevice {
+        let vendorId: UInt16
+        let productId: UInt16
+        let name: String
+        let properties: [String: Any]
+
+        init(vendorId: UInt16, productId: UInt16, name: String) {
+            self.vendorId = vendorId
+            self.productId = productId
+            self.name = name
+            self.properties = [
+                "idVendor": NSNumber(value: vendorId),
+                "idProduct": NSNumber(value: productId),
+                "USB Product Name": name,
+            ]
+        }
+    }
+
+    /// Mock IOKit service for testing
+    class MockIOKitService: IOKitServiceProtocol, @unchecked Sendable {
+
+        // Thread safety
+        private let lock = NSLock()
+
+        // Test configuration
+        var shouldFailNotificationPort = false
+        var shouldFailRunLoopSource = false
+        var shouldFailMatchingDictionary = false
+        var shouldFailAddNotification = false
+
+        // Mock data (protected by lock)
+        private var mockDevices: [io_service_t: MockDevice] = [:]
+        private var deviceProperties: [io_service_t: [String: Any]] = [:]
+        private var nextDeviceId: io_service_t = 1000
+
+        // Callback storage for simulation
+        private var matchedCallback: IOServiceMatchingCallback?
+        private var terminatedCallback: IOServiceMatchingCallback?
+        private var callbackRefcon: UnsafeMutableRawPointer?
+
+        // Test tracking
+        var createNotificationPortCallCount = 0
+        var addNotificationCallCount = 0
+        var iteratorNextCallCount = 0
+        var objectReleaseCallCount = 0
+        var getPropertiesCallCount = 0
+
+        init() {}
+
+        // MARK: - IOKitServiceProtocol Implementation
+
+        func createNotificationPort() -> IONotificationPortRef? {
+            createNotificationPortCallCount += 1
+
+            if shouldFailNotificationPort {
+                return nil
+            }
+
+            // Return a fake pointer for testing
+            return OpaquePointer(bitPattern: 0x1234)
+        }
+
+        func getRunLoopSource(_ port: IONotificationPortRef) -> CFRunLoopSource? {
+            if shouldFailRunLoopSource {
+                return nil
+            }
+
+            // Create a dummy run loop source for testing
+            // This is a bit hacky but necessary for testing
+            var context = CFRunLoopSourceContext()
+            return withUnsafeMutablePointer(to: &context) { contextPtr in
+                return CFRunLoopSourceCreate(nil, 0, contextPtr)
+            }
+        }
+
+        func createUSBDeviceMatchingDictionary() -> CFMutableDictionary? {
+            if shouldFailMatchingDictionary {
+                return nil
+            }
+
+            return CFDictionaryCreateMutable(nil, 0, nil, nil)
+        }
+
+        func addMatchingNotification(
+            port: IONotificationPortRef,
+            type: String,
+            matching: CFMutableDictionary,
+            callback: IOServiceMatchingCallback,
+            refcon: UnsafeMutableRawPointer,
+            iterator: UnsafeMutablePointer<io_iterator_t>
+        ) -> kern_return_t {
+            addNotificationCallCount += 1
+
+            if shouldFailAddNotification {
+                return KERN_FAILURE
+            }
+
+            // Store callbacks for simulation
+            if type == kIOMatchedNotification {
+                matchedCallback = callback
+            } else if type == kIOTerminatedNotification {
+                terminatedCallback = callback
+            }
+            callbackRefcon = refcon
+
+            // Set a fake iterator value
+            iterator.pointee = 2000
+
+            return KERN_SUCCESS
+        }
+
+        func iteratorNext(_ iterator: io_iterator_t) -> io_service_t {
+            iteratorNextCallCount += 1
+
+            // Find the mock iterator and get next device
+            if let mockIterator = MockIteratorManager.shared.getIterator(iterator) {
+                return mockIterator.next()
+            }
+
+            // Return 0 to indicate no more devices (real IOKit behavior)
+            return 0
+        }
+
+        func objectRelease(_ object: io_object_t) {
+            objectReleaseCallCount += 1
+        }
+
+        func getDeviceProperties(_ device: io_service_t) -> [String: Any]? {
+            getPropertiesCallCount += 1
+            lock.lock()
+            defer { lock.unlock() }
+            return deviceProperties[device]
+        }
+
+        func destroyNotificationPort(_ port: IONotificationPortRef) {
+            // Nothing to do for mock
+        }
+
+        // MARK: - Test Simulation Methods
+
+        /// Simulates a device connection by triggering the matched callback
+        func simulateDeviceConnection(_ device: MockDevice) {
+            lock.lock()
+            let deviceId = nextDeviceId
+            nextDeviceId += 1
+
+            // Store device data
+            mockDevices[deviceId] = device
+            deviceProperties[deviceId] = device.properties
+            lock.unlock()
+
+            // Create a mock iterator that will return this device
+            let mockIterator = MockIterator(devices: [deviceId])
+
+            // Trigger the callback if registered
+            if let callback = matchedCallback, let refcon = callbackRefcon {
+                callback(refcon, mockIterator.iteratorId)
+            }
+        }
+
+        /// Simulates a device disconnection by triggering the terminated callback
+        func simulateDeviceDisconnection(_ device: MockDevice) {
+            lock.lock()
+            // Find the device ID
+            guard let deviceId = mockDevices.first(where: { $0.value.name == device.name })?.key
+            else {
+                lock.unlock()
+                return
+            }
+            lock.unlock()
+
+            // Create a mock iterator that will return this device
+            let mockIterator = MockIterator(devices: [deviceId])
+
+            // Trigger the callback if registered
+            if let callback = terminatedCallback, let refcon = callbackRefcon {
+                callback(refcon, mockIterator.iteratorId)
+            }
+
+            // Note: We DON'T remove device data here because the callback processing
+            // (processUSBDevice -> getDeviceProperties) needs the data to still be available.
+            // In real IOKit, the device properties are still accessible during termination processing.
+            // We could remove it later, but for testing purposes we'll leave it.
+        }
+
+        /// Simulates multiple device connections
+        func simulateMultipleDeviceConnections(_ devices: [MockDevice]) async {
+            for device in devices {
+                simulateDeviceConnection(device)
+                // Add a small delay to allow async callback processing
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
+        // MARK: - Test Helper Methods
+
+        func resetCounts() {
+            createNotificationPortCallCount = 0
+            addNotificationCallCount = 0
+            iteratorNextCallCount = 0
+            objectReleaseCallCount = 0
+            getPropertiesCallCount = 0
+        }
+
+        func setAllFailures(_ shouldFail: Bool) {
+            shouldFailNotificationPort = shouldFail
+            shouldFailRunLoopSource = shouldFail
+            shouldFailMatchingDictionary = shouldFail
+            shouldFailAddNotification = shouldFail
+        }
+
+        func getDeviceCount() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return mockDevices.count
+        }
+    }
+
+    /// Helper class to manage mock iterators
+    private class MockIterator {
+        let iteratorId: io_iterator_t
+        let devices: [io_service_t]
+        private var currentIndex = 0
+
+        init(devices: [io_service_t]) {
+            self.iteratorId = io_iterator_t(Int.random(in: 3000...9999))
+            self.devices = devices
+
+            // Store this iterator globally so iteratorNext can find it
+            MockIteratorManager.shared.addIterator(self)
+        }
+
+        func next() -> io_service_t {
+            guard currentIndex < devices.count else {
+                return 0  // No more devices
+            }
+
+            let device = devices[currentIndex]
+            currentIndex += 1
+            return device
+        }
+    }
+
+    /// Global manager for mock iterators (needed because IOKit callbacks use C function pointers)
+    private class MockIteratorManager: @unchecked Sendable {
+        static let shared = MockIteratorManager()
+        private let lock = NSLock()
+        private var iterators: [io_iterator_t: MockIterator] = [:]
+
+        func addIterator(_ iterator: MockIterator) {
+            lock.lock()
+            defer { lock.unlock() }
+            iterators[iterator.iteratorId] = iterator
+        }
+
+        func getIterator(_ id: io_iterator_t) -> MockIterator? {
+            lock.lock()
+            defer { lock.unlock() }
+            return iterators[id]
+        }
+
+        func removeIterator(_ id: io_iterator_t) {
+            lock.lock()
+            defer { lock.unlock() }
+            iterators.removeValue(forKey: id)
+        }
+    }
+
+#endif  // os(macOS)

--- a/Tests/EdgeHelperMacOSTests/mocks/MockNetworkInterfaceMonitor.swift
+++ b/Tests/EdgeHelperMacOSTests/mocks/MockNetworkInterfaceMonitor.swift
@@ -1,0 +1,69 @@
+#if os(macOS)
+    import EdgeShared
+    import Foundation
+    import Logging
+
+    @testable import edge_helper
+
+    /// Mock network interface monitor for testing
+    actor MockNetworkInterfaceMonitor: NetworkInterfaceMonitorProtocol {
+        private var isRunning = false
+        private var interfaceHandler: (@Sendable (NetworkInterfaceEvent) -> Void)?
+
+        // Test control properties
+        var shouldFailStart = false
+        var startCallCount = 0
+        var stopCallCount = 0
+
+        init() {}
+
+        func start() async throws {
+            startCallCount += 1
+
+            if shouldFailStart {
+                throw NetworkInterfaceMonitorError.failedToCreateDynamicStore
+            }
+
+            isRunning = true
+        }
+
+        func stop() async {
+            stopCallCount += 1
+            isRunning = false
+        }
+
+        func setInterfaceHandler(
+            _ handler: @escaping @Sendable (NetworkInterfaceEvent) -> Void
+        ) async {
+            self.interfaceHandler = handler
+        }
+
+        // Test helper methods
+        func simulateInterfaceAppearance(_ interfaceName: String) async {
+            guard isRunning else { return }
+            interfaceHandler?(.interfaceAppeared(interfaceName))
+        }
+
+        func simulateInterfaceDisappearance(_ interfaceName: String) async {
+            guard isRunning else { return }
+            interfaceHandler?(.interfaceDisappeared(interfaceName))
+        }
+
+        func getIsRunning() async -> Bool {
+            return isRunning
+        }
+
+        func resetCounts() async {
+            startCallCount = 0
+            stopCallCount = 0
+        }
+    }
+
+    // Extend NetworkInterfaceMonitor to be testable
+    extension NetworkInterfaceMonitor {
+        static func mock() -> MockNetworkInterfaceMonitor {
+            return MockNetworkInterfaceMonitor()
+        }
+    }
+
+#endif  // os(macOS)


### PR DESCRIPTION
 Replace polling-based network interface detection with real-time event-driven
  monitoring using SystemConfiguration framework. This eliminates 2-6 second
  retry delays when EdgeOS USB devices connect but their ethernet interfaces
  aren't immediately available.

  Key changes:
  • Add NetworkInterfaceMonitor using SCDynamicStore for real-time network events
  • Create NetworkInterfaceMonitorProtocol for testability and dependency injection
  • Integrate event-driven monitoring with EdgeHelperDaemon on macOS
  • Store USB devices as pending until network interface events trigger configuration
  • Fix interface filtering to detect any Ethernet interface (en*, eth*) instead of EdgeOS-named only
  • Add MockNetworkInterfaceMonitor for comprehensive test coverage
  • Update all tests to use event-driven approach with network interface simulation
