### PR TITLE
Add StopContainer RPC and associated command for managing container l…

### DIFF
--- a/Proto/edge/agent/services/v1/edge_agent_v1_container_service.proto
+++ b/Proto/edge/agent/services/v1/edge_agent_v1_container_service.proto
@@ -6,6 +6,7 @@ service EdgeContainerService {
     rpc ListLayers(ListLayersRequest) returns (stream LayerHeader);
     rpc WriteLayer(stream WriteLayerRequest) returns (stream WriteLayerResponse);
     rpc RunContainer(RunContainerLayersRequest) returns (RunContainerLayersResponse);
+    rpc StopContainer(StopContainerRequest) returns (StopContainerResponse);
 }
 
 message ListLayersRequest {}
@@ -57,3 +58,9 @@ message RunContainerLayerHeader {
 }
 
 message RunContainerLayersResponse {}
+
+message StopContainerRequest {
+    string app_name = 1;
+}
+
+message StopContainerResponse {}

--- a/Proto/edge/agent/services/v1/edge_agent_v1_service.proto
+++ b/Proto/edge/agent/services/v1/edge_agent_v1_service.proto
@@ -59,23 +59,45 @@ message RunContainerRequest {
 message ControlCommand {
     oneof command {
         Run run = 1;
+        Stop stop = 2;
     }
 
     message Run {
         // Whether to run the container with a debugger
         bool debug = 1;
+
+        // Optional restart policy override for Docker runtime.
+        enum RestartPolicy {
+            DEFAULT = 0;          // Agent chooses default (unless-stopped for normal runs)
+            UNLESS_STOPPED = 1;   // --restart unless-stopped
+            NO = 2;               // --restart no
+            ON_FAILURE = 3;       // --restart on-failure:N (see on_failure_max_retries)
+        }
+
+        optional RestartPolicy restart_policy = 2;
+        // Only used when restart_policy==ON_FAILURE
+        optional int32 on_failure_max_retries = 3;
+    }
+
+    message Stop {
+        // No fields needed; acts on the current container in this stream
     }
 }
 
 message RunContainerResponse {
     oneof response_type {
         Started started = 1;
+        Stopped stopped = 2;
     }
 
     message Started {
         // The port that the debugger is listening on.
         // If this is 0, the container is not running with a debugger.
         uint32 debug_port = 1;
+    }
+
+    message Stopped {
+        // No fields; indicates container has been stopped
     }
 }
 

--- a/Sources/Edge/EdgeCLI.swift
+++ b/Sources/Edge/EdgeCLI.swift
@@ -11,6 +11,7 @@ struct EdgeCLI: AsyncParsableCommand {
         subcommands: [
             InitCommand.self,
             RunCommand.self,
+            ContainerCommand.self,
             DevicesCommand.self,
             HardwareCommand.self,
             ImagerCommand.self,

--- a/Sources/Edge/cli/commands/ContainerCommand.swift
+++ b/Sources/Edge/cli/commands/ContainerCommand.swift
@@ -1,0 +1,38 @@
+import ArgumentParser
+import EdgeAgentGRPC
+import GRPCCore
+import GRPCNIOTransportHTTP2
+import Logging
+
+struct ContainerCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "container",
+        abstract: "Manage containers on the device",
+        subcommands: [
+            Stop.self,
+        ]
+    )
+
+    struct Stop: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "stop",
+            abstract: "Stop a running container (containerd runtime)"
+        )
+
+        @Argument(help: "Application name used when the container was created")
+        var appName: String
+
+        @OptionGroup var agentConnectionOptions: AgentConnectionOptions
+
+        func run() async throws {
+            let logger = Logger(label: "edgeengineer.cli.container.stop")
+            try await withGRPCClient(agentConnectionOptions) { client in
+                let containers = Edge_Agent_Services_V1_EdgeContainerService.Client(wrapping: client)
+                _ = try await containers.stopContainer(
+                    .with { $0.appName = appName }
+                )
+                logger.info("Stop request sent", metadata: ["app": .string(appName)])
+            }
+        }
+    }
+}

--- a/Sources/EdgeAgent/DockerCLI.swift
+++ b/Sources/EdgeAgent/DockerCLI.swift
@@ -42,6 +42,13 @@ public struct DockerCLI: Sendable {
         /// Give extended privileges to this container
         case privileged
 
+        /// Set restart policy to unless-stopped
+        case restartUnlessStopped
+        /// Set restart policy to no
+        case restartNo
+        /// Set restart policy to on-failure with max retries
+        case restartOnFailure(Int)
+
         /// The arguments to pass to the Docker run command.
         var arguments: [String] {
             switch self {
@@ -67,6 +74,12 @@ public struct DockerCLI: Sendable {
                 return ["--device", device]
             case .privileged:
                 return ["--privileged"]
+            case .restartUnlessStopped:
+                return ["--restart", "unless-stopped"]
+            case .restartNo:
+                return ["--restart", "no"]
+            case .restartOnFailure(let retries):
+                return ["--restart", "on-failure:\(retries)"]
             }
         }
     }
@@ -103,6 +116,26 @@ public struct DockerCLI: Sendable {
         let result = try await Subprocess.run(
             Subprocess.Executable.name(command),
             arguments: Subprocess.Arguments(allArguments),
+            output: .string
+        )
+        return result.standardOutput ?? ""
+    }
+
+    /// Stop a Docker container gracefully.
+    /// - Parameters:
+    ///   - container: The container name or ID to stop.
+    ///   - timeoutSeconds: Optional timeout to wait before killing the container.
+    /// - Returns: Standard output from the Docker CLI.
+    @discardableResult
+    public func stop(container: String, timeoutSeconds: Int? = nil) async throws -> String {
+        var args = ["stop"]
+        if let timeoutSeconds {
+            args += ["--time", String(timeoutSeconds)]
+        }
+        args.append(container)
+        let result = try await Subprocess.run(
+            Subprocess.Executable.name(self.command),
+            arguments: Subprocess.Arguments(args),
             output: .string
         )
         return result.standardOutput ?? ""

--- a/Sources/EdgeAgent/Services/RunContainerRequestHandler+Proto.swift
+++ b/Sources/EdgeAgent/Services/RunContainerRequestHandler+Proto.swift
@@ -26,7 +26,23 @@ extension RunContainerRequestHandler.ControlCommand {
     init(validating proto: Edge_Agent_Services_V1_ControlCommand) throws {
         switch proto.command {
         case .run(let run):
-            self = .run(Run(debug: run.debug))
+            var restart: Run.RestartPolicy = .default
+            switch run.restartPolicy {
+            case .unlessStopped:
+                restart = .unlessStopped
+            case .no:
+                restart = .no
+            case .onFailure:
+                let retries = Int(run.onFailureMaxRetries)
+                restart = .onFailure(max(0, retries))
+            case .defaultPolicy:
+                restart = .default
+            case .UNRECOGNIZED:
+                restart = .default
+            }
+            self = .run(Run(debug: run.debug, restartPolicy: restart))
+        case .stop:
+            self = .stop
         case nil:
             throw RPCError(code: .invalidArgument, message: "Control command cannot be unspecified")
         }
@@ -43,6 +59,8 @@ extension RunContainerRequestHandler.Event {
                         $0.debugPort = containerStarted.debugPort
                     }
                 )
+            case .containerStopped:
+                $0.responseType = .stopped(.init())
             }
         }
     }

--- a/Sources/EdgeAgentGRPC/Proto/edge/agent/services/v1/edge_agent_v1_container_service.grpc.swift
+++ b/Sources/EdgeAgentGRPC/Proto/edge/agent/services/v1/edge_agent_v1_container_service.grpc.swift
@@ -55,11 +55,24 @@ public enum Edge_Agent_Services_V1_EdgeContainerService {
                 method: "RunContainer"
             )
         }
+        /// Namespace for "StopContainer" metadata.
+        public enum StopContainer {
+            /// Request type for "StopContainer".
+            public typealias Input = Edge_Agent_Services_V1_StopContainerRequest
+            /// Response type for "StopContainer".
+            public typealias Output = Edge_Agent_Services_V1_StopContainerResponse
+            /// Descriptor for "StopContainer".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "edge.agent.services.v1.EdgeContainerService"),
+                method: "StopContainer"
+            )
+        }
         /// Descriptors for all methods in the "edge.agent.services.v1.EdgeContainerService" service.
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             ListLayers.descriptor,
             WriteLayer.descriptor,
-            RunContainer.descriptor
+            RunContainer.descriptor,
+            StopContainer.descriptor
         ]
     }
 }
@@ -124,6 +137,20 @@ extension Edge_Agent_Services_V1_EdgeContainerService {
             request: GRPCCore.StreamingServerRequest<Edge_Agent_Services_V1_RunContainerLayersRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.StreamingServerResponse<Edge_Agent_Services_V1_RunContainerLayersResponse>
+
+        /// Handle the "StopContainer" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Edge_Agent_Services_V1_StopContainerRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Edge_Agent_Services_V1_StopContainerResponse` message.
+        func stopContainer(
+            request: GRPCCore.StreamingServerRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Edge_Agent_Services_V1_StopContainerResponse>
     }
 
     /// Service protocol for the "edge.agent.services.v1.EdgeContainerService" service.
@@ -175,6 +202,20 @@ extension Edge_Agent_Services_V1_EdgeContainerService {
             request: GRPCCore.ServerRequest<Edge_Agent_Services_V1_RunContainerLayersRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.ServerResponse<Edge_Agent_Services_V1_RunContainerLayersResponse>
+
+        /// Handle the "StopContainer" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request of `Edge_Agent_Services_V1_StopContainerRequest`.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Edge_Agent_Services_V1_StopContainerResponse` message.
+        func stopContainer(
+            request: GRPCCore.ServerRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Edge_Agent_Services_V1_StopContainerResponse>
     }
 
     /// Simple service protocol for the "edge.agent.services.v1.EdgeContainerService" service.
@@ -226,6 +267,20 @@ extension Edge_Agent_Services_V1_EdgeContainerService {
             request: Edge_Agent_Services_V1_RunContainerLayersRequest,
             context: GRPCCore.ServerContext
         ) async throws -> Edge_Agent_Services_V1_RunContainerLayersResponse
+
+        /// Handle the "StopContainer" method.
+        ///
+        /// - Parameters:
+        ///   - request: A `Edge_Agent_Services_V1_StopContainerRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Edge_Agent_Services_V1_StopContainerResponse` to respond with.
+        func stopContainer(
+            request: Edge_Agent_Services_V1_StopContainerRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Edge_Agent_Services_V1_StopContainerResponse
     }
 }
 
@@ -265,6 +320,17 @@ extension Edge_Agent_Services_V1_EdgeContainerService.StreamingServiceProtocol {
                 )
             }
         )
+        router.registerHandler(
+            forMethod: Edge_Agent_Services_V1_EdgeContainerService.Method.StopContainer.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Edge_Agent_Services_V1_StopContainerRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Edge_Agent_Services_V1_StopContainerResponse>(),
+            handler: { request, context in
+                try await self.stopContainer(
+                    request: request,
+                    context: context
+                )
+            }
+        )
     }
 }
 
@@ -286,6 +352,17 @@ extension Edge_Agent_Services_V1_EdgeContainerService.ServiceProtocol {
         context: GRPCCore.ServerContext
     ) async throws -> GRPCCore.StreamingServerResponse<Edge_Agent_Services_V1_RunContainerLayersResponse> {
         let response = try await self.runContainer(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+
+    public func stopContainer(
+        request: GRPCCore.StreamingServerRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Edge_Agent_Services_V1_StopContainerResponse> {
+        let response = try await self.stopContainer(
             request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
@@ -335,6 +412,19 @@ extension Edge_Agent_Services_V1_EdgeContainerService.SimpleServiceProtocol {
     ) async throws -> GRPCCore.ServerResponse<Edge_Agent_Services_V1_RunContainerLayersResponse> {
         return GRPCCore.ServerResponse<Edge_Agent_Services_V1_RunContainerLayersResponse>(
             message: try await self.runContainer(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+
+    public func stopContainer(
+        request: GRPCCore.ServerRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Edge_Agent_Services_V1_StopContainerResponse> {
+        return GRPCCore.ServerResponse<Edge_Agent_Services_V1_StopContainerResponse>(
+            message: try await self.stopContainer(
                 request: request.message,
                 context: context
             ),
@@ -406,6 +496,25 @@ extension Edge_Agent_Services_V1_EdgeContainerService {
             deserializer: some GRPCCore.MessageDeserializer<Edge_Agent_Services_V1_RunContainerLayersResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Edge_Agent_Services_V1_RunContainerLayersResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "StopContainer" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Edge_Agent_Services_V1_StopContainerRequest` message.
+        ///   - serializer: A serializer for `Edge_Agent_Services_V1_StopContainerRequest` messages.
+        ///   - deserializer: A deserializer for `Edge_Agent_Services_V1_StopContainerResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func stopContainer<Result>(
+            request: GRPCCore.ClientRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+            serializer: some GRPCCore.MessageSerializer<Edge_Agent_Services_V1_StopContainerRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Edge_Agent_Services_V1_StopContainerResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Edge_Agent_Services_V1_StopContainerResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -510,6 +619,36 @@ extension Edge_Agent_Services_V1_EdgeContainerService {
                 onResponse: handleResponse
             )
         }
+
+        /// Call the "StopContainer" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Edge_Agent_Services_V1_StopContainerRequest` message.
+        ///   - serializer: A serializer for `Edge_Agent_Services_V1_StopContainerRequest` messages.
+        ///   - deserializer: A deserializer for `Edge_Agent_Services_V1_StopContainerResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func stopContainer<Result>(
+            request: GRPCCore.ClientRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+            serializer: some GRPCCore.MessageSerializer<Edge_Agent_Services_V1_StopContainerRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Edge_Agent_Services_V1_StopContainerResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Edge_Agent_Services_V1_StopContainerResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Edge_Agent_Services_V1_EdgeContainerService.Method.StopContainer.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
     }
 }
 
@@ -581,6 +720,31 @@ extension Edge_Agent_Services_V1_EdgeContainerService.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<Edge_Agent_Services_V1_RunContainerLayersRequest>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<Edge_Agent_Services_V1_RunContainerLayersResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "StopContainer" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Edge_Agent_Services_V1_StopContainerRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func stopContainer<Result>(
+        request: GRPCCore.ClientRequest<Edge_Agent_Services_V1_StopContainerRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Edge_Agent_Services_V1_StopContainerResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.stopContainer(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Edge_Agent_Services_V1_StopContainerRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Edge_Agent_Services_V1_StopContainerResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -667,6 +831,35 @@ extension Edge_Agent_Services_V1_EdgeContainerService.ClientProtocol {
             metadata: metadata
         )
         return try await self.runContainer(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "StopContainer" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func stopContainer<Result>(
+        _ message: Edge_Agent_Services_V1_StopContainerRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Edge_Agent_Services_V1_StopContainerResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Edge_Agent_Services_V1_StopContainerRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.stopContainer(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/Sources/EdgeAgentGRPC/Proto/edge/agent/services/v1/edge_agent_v1_container_service.pb.swift
+++ b/Sources/EdgeAgentGRPC/Proto/edge/agent/services/v1/edge_agent_v1_container_service.pb.swift
@@ -127,6 +127,28 @@ public struct Edge_Agent_Services_V1_RunContainerLayersResponse: Sendable {
   public init() {}
 }
 
+public struct Edge_Agent_Services_V1_StopContainerRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var appName: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Edge_Agent_Services_V1_StopContainerResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "edge.agent.services.v1"
@@ -371,6 +393,53 @@ extension Edge_Agent_Services_V1_RunContainerLayersResponse: SwiftProtobuf.Messa
   }
 
   public static func ==(lhs: Edge_Agent_Services_V1_RunContainerLayersResponse, rhs: Edge_Agent_Services_V1_RunContainerLayersResponse) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Edge_Agent_Services_V1_StopContainerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".StopContainerRequest"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "app_name"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.appName) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.appName.isEmpty {
+      try visitor.visitSingularStringField(value: self.appName, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Edge_Agent_Services_V1_StopContainerRequest, rhs: Edge_Agent_Services_V1_StopContainerRequest) -> Bool {
+    if lhs.appName != rhs.appName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Edge_Agent_Services_V1_StopContainerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".StopContainerResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Edge_Agent_Services_V1_StopContainerResponse, rhs: Edge_Agent_Services_V1_StopContainerResponse) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
Maps `--restart=unless-stopped` and `--restart=no` and `--restart=on-failure:${number}` to `DockerCLI`

- Introduced StopContainer RPC in EdgeContainerService to stop running containers.
- Added ContainerCommand with a Stop subcommand to facilitate stopping containers via CLI.
- Enhanced ControlCommand to support stop operations and added restart policy options for container execution.
- Updated DockerCLI to include stop functionality for Docker containers.
- Modified RunContainerRequestHandler to handle stopping containers and manage their state effectively.

Note `debug` has `--restart-no` 