### PR TITLE
If Swift fails to find the resources (ds2), look next to the executable as well

### DIFF
--- a/Sources/Edge/cli/commands/RunCommand.swift
+++ b/Sources/Edge/cli/commands/RunCommand.swift
@@ -154,13 +154,28 @@ struct RunCommand: AsyncParsableCommand, Sendable {
 
         if debug {
             // Include the ds2 executable in the container image.
-            guard
-                let ds2URL = Bundle.module.url(
+            let ds2URL: URL
+            if
+                let url = Bundle.module.url(
                     forResource: "ds2-124963fd-static-linux-arm64",
                     withExtension: nil
                 )
-            else {
-                fatalError("Could not find ds2 executable in bundle resources")
+            {
+                ds2URL = url
+            } else {
+                let url = URL(fileURLWithPath: CommandLine.arguments[0])
+                    .deletingLastPathComponent()
+                    .appending(path: "edge-agent_edge.bundle")
+                    .appending(path: "Contents")
+                    .appending(path: "Resources")
+                    .appending(path: "Resources")
+                    .appending(component: "ds2-124963fd-static-linux-arm64")
+                
+                guard FileManager.default.fileExists(atPath: url.path()) else {
+                    fatalError("Could not find ds2 executable in bundle resources")
+                }
+                
+                ds2URL = url
             }
 
             let ds2Files = [
@@ -344,13 +359,28 @@ struct RunCommand: AsyncParsableCommand, Sendable {
 
         if debug {
             // Include the ds2 executable in the container image.
-            guard
-                let ds2URL = Bundle.module.url(
+            let ds2URL: URL
+            if
+                let url = Bundle.module.url(
                     forResource: "ds2-124963fd-static-linux-arm64",
                     withExtension: nil
                 )
-            else {
-                fatalError("Could not find ds2 executable in bundle resources")
+            {
+                ds2URL = url
+            } else {
+                let url = URL(fileURLWithPath: CommandLine.arguments[0])
+                    .deletingLastPathComponent()
+                    .appending(path: "edge-agent_edge.bundle")
+                    .appending(path: "Contents")
+                    .appending(path: "Resources")
+                    .appending(path: "Resources")
+                    .appending(component: "ds2-124963fd-static-linux-arm64")
+                
+                guard FileManager.default.fileExists(atPath: url.path()) else {
+                    fatalError("Could not find ds2 executable in bundle resources")
+                }
+                
+                ds2URL = url
             }
 
             let ds2Files = [


### PR DESCRIPTION
This makes it possible to run and debug `edge` from Xcode and should make it a bit more graceful